### PR TITLE
Fix admin rules/roles layout width

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,6 @@
 /* style.css */
-/* Version: 1.2.29 */
-/* Note: Enhanced layout for admin manage areas with better spacing and z-index fixes. Compatible with app.py (1.2.107), script.js (1.2.84), forms.py (1.2.19), config.py (1.2.6), admin_manage.html (1.2.43), incentive.html (1.2.45), quick_adjust.html (1.2.18), base.html (1.2.21), macros.html (1.2.13), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.6), incentive_service.py (1.2.27), history.html (1.2.6), error.html, init_db.py (1.2.4). */
+/* Version: 1.2.30 */
+/* Note: Expanded Rules and Manage Roles sections to use full width for improved layout. Compatible with app.py (1.2.107), script.js (1.2.84), forms.py (1.2.19), config.py (1.2.6), admin_manage.html (1.2.43), incentive.html (1.2.45), quick_adjust.html (1.2.18), base.html (1.2.21), macros.html (1.2.13), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.6), incentive_service.py (1.2.27), history.html (1.2.6), error.html, init_db.py (1.2.4). */
 
 body {
     font-family: 'Inter', 'Montserrat', Arial, sans-serif;
@@ -13,7 +13,7 @@ body {
 }
 
 body::after {
-    content: 'v1.2.29';
+    content: 'v1.2.30';
     display: none;
 }
 
@@ -262,14 +262,19 @@ table#scoreboard tbody tr.score-high td {
 div.rules-container, div.manage-roles-container {
     display: flex;
     justify-content: space-between;
-    max-width: 900px;
-    margin: 20px auto;
+    width: 100%;
+    margin: 20px 0;
     gap: 20px;
     background: #00000033;
     padding: 20px;
     border-radius: 10px;
     border: 1px solid #D4AF37;
     z-index: 1;
+}
+
+div.rules-container > *,
+div.manage-roles-container > * {
+    flex: 1;
 }
 
 div.rules-column {


### PR DESCRIPTION
## Summary
- Expand rules and manage roles containers to full width for smoother admin UX
- Ensure child sections flex to use available space

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fc6d4a7c88325b9b57a70fe891cf6