### PR TITLE
Fix history view and rule sorting

### DIFF
--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -136,7 +136,11 @@
 
         <div class="rules-container">
             <h2>Rules</h2>
-            {{ macros.render_rule_list(rules, 'rule', 'admin_edit_rule', 'admin_remove_rule', edit_form=True) }}
+            <div class="mb-2">
+                <button type="button" id="sortAlpha" class="btn btn-secondary btn-sm">Sort A-Z</button>
+                <button type="button" id="sortPoints" class="btn btn-secondary btn-sm">Sort by Points</button>
+            </div>
+            {{ macros.render_rule_list(rules, 'rule', 'admin_edit_rule', 'admin_remove_rule', edit_form=True, list_id='RulesList') }}
         </div>
 
         <div class="add-employee-container">

--- a/templates/history.html
+++ b/templates/history.html
@@ -7,9 +7,9 @@
 {% block content %}
 <h1>Score History</h1>
 <form method="GET" action="{{ url_for('history') }}">
-    {{ macros.render_select_field(name='month_year', id='month_year', label_text='Select Month', options=months, selected_value=selected_month) }}
+    {{ macros.render_select_field({'name': 'month_year', 'errors': []}, id='month_year', label_text='Select Month', options=months, selected_value=selected_month) }}
     {% if days %}
-        {{ macros.render_select_field(name='day', id='day', label_text='Select Day', options=days, selected_value=selected_day) }}
+        {{ macros.render_select_field({'name': 'day', 'errors': []}, id='day', label_text='Select Day', options=days, selected_value=selected_day) }}
     {% endif %}
     {{ macros.render_submit_button('Filter') }}
 </form>

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -94,16 +94,31 @@
 
         <div class="rules-container">
             <h2>Point Conditions</h2>
-            <ul class="list-unstyled">
-                {% for rule in rules %}
-                    <li>
-                        <a href="#" class="quick-adjust-link" data-points="{{ rule.points }}" data-reason="{{ rule.description }}">{{ rule.description }} ({{ rule.points }} points)</a>
-                        {% if rule.details %}
-                            <span class="tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ rule.details }}">?</span>
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ul>
+            {% set half = (rules|length + 1) // 2 %}
+            <div class="rules-column">
+                <ul class="list-unstyled">
+                    {% for rule in rules[:half] %}
+                        <li>
+                            <a href="#" class="quick-adjust-link" data-points="{{ rule.points }}" data-reason="{{ rule.description }}">{{ rule.description }} ({{ rule.points }} points)</a>
+                            {% if rule.details %}
+                                <span class="tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ rule.details }}">?</span>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            <div class="rules-column">
+                <ul class="list-unstyled">
+                    {% for rule in rules[half:] %}
+                        <li>
+                            <a href="#" class="quick-adjust-link" data-points="{{ rule.points }}" data-reason="{{ rule.description }}">{{ rule.description }} ({{ rule.points }} points)</a>
+                            {% if rule.details %}
+                                <span class="tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ rule.details }}">?</span>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
         </div>
 
         <div class="pot-container">

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -60,13 +60,13 @@
     <input type="hidden" id="{{ id }}" name="csrf_token" value="{{ csrf_token() }}">
 {% endmacro %}
 
-{% macro render_rule_list(items, type, edit_endpoint, remove_endpoint, edit_form=None) %}
+{% macro render_rule_list(items, type, edit_endpoint, remove_endpoint, edit_form=None, list_id='') %}
     <div class="{{ type }}-container">
-        <ul class="list-unstyled">
+        <ul class="list-unstyled"{% if list_id %} id="{{ list_id }}"{% endif %}>
             {% for item in items %}
-                <li>
+                <li{% if type == 'rule' %} data-description="{{ item.description }}" data-points="{{ item.points }}"{% endif %}>
                     <span>
-                        {{ item.description if type == 'rule' else item.role_name }} 
+                        {{ item.description if type == 'rule' else item.role_name }}
                         ({{ item.points if type == 'rule' else item.percentage }}%)
                         {% if item.details %}
                             <span class="tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ item.details }}">?</span>


### PR DESCRIPTION
## Summary
- Fix history page select fields to prevent template errors
- Show rules in two columns on main page
- Add manual/alpha/points rule sorting with persistence for admins

## Testing
- `python -m py_compile app.py incentive_service.py forms.py config.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688fd2e0f5708325bff90ae57c8bd13a