### PR TITLE
Fix history view and rule sorting

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,6 +1,6 @@
 // script.js
-// Version: 1.2.85
-// Note: Fixed point decay editing by removing duplicate handler and dynamically populating days. Compatible with app.py (1.2.108), forms.py (1.2.19), config.py (1.2.6), admin_manage.html (1.2.44), incentive.html (1.2.47), quick_adjust.html (1.2.18), style.css (1.2.31), base.html (1.2.21), macros.html (1.2.14), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.6), incentive_service.py (1.2.27), history.html (1.2.6), error.html, init_db.py (1.2.4).
+// Version: 1.2.86
+// Note: Fixed point decay editing by removing duplicate handler and dynamically populating days. Added CSRF token support when saving rule order. Compatible with app.py (1.2.108), forms.py (1.2.19), config.py (1.2.6), admin_manage.html (1.2.45), incentive.html (1.2.47), quick_adjust.html (1.2.18), style.css (1.2.31), base.html (1.2.21), macros.html (1.2.14), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.6), incentive_service.py (1.2.27), history.html (1.2.6), error.html, init_db.py (1.2.4).
 
 // Verify Bootstrap Availability
 if (typeof bootstrap === 'undefined') {
@@ -1357,33 +1357,65 @@ document.addEventListener('DOMContentLoaded', function () {
     const rulesList = document.getElementById('RulesList');
     if (rulesList) {
         console.log('Initializing Sortable for RulesList');
+
+        function saveRuleOrder() {
+            const order = Array.from(rulesList.children).map(item => item.getAttribute('data-description'));
+            const csrfToken = document.getElementById('reorder_rules_csrf_token');
+            if (!csrfToken) {
+                console.error('CSRF Token for rule reordering not found');
+                alert('Error: CSRF token missing. Please refresh and try again.');
+                return;
+            }
+            const params = new URLSearchParams();
+            order.forEach(desc => params.append('order[]', desc));
+            params.append('csrf_token', csrfToken.value);
+            console.log(`CSRF Token Included: ${csrfToken.value}`);
+            fetch('/admin/reorder_rules', {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                },
+                body: params
+            })
+            .then(handleResponse)
+            .then(data => {
+                if (data) {
+                    console.log('Reorder Rules Response:', data);
+                    alert(data.message);
+                    if (data.success) window.location.reload();
+                }
+            })
+            .catch(error => console.error('Error reordering rules:', error));
+        }
+
         if (typeof Sortable !== 'undefined') {
-            const sortable = new Sortable(rulesList, {
+            new Sortable(rulesList, {
                 animation: 150,
                 ghostClass: 'sortable-ghost',
-                onEnd: function () {
-                    const order = Array.from(rulesList.children).map(item => item.getAttribute('data-description'));
-                    console.log('Rules Reordered:', order);
-                    fetch('/admin/reorder_rules', {
-                        method: 'POST',
-                        headers: {
-                            'Content-Type': 'application/x-www-form-urlencoded'
-                        },
-                        body: 'order[]=' + order.map(encodeURIComponent).join('&order[]=')
-                    })
-                    .then(handleResponse)
-                    .then(data => {
-                        if (data) {
-                            console.log('Reorder Rules Response:', data);
-                            alert(data.message);
-                            if (data.success) window.location.reload();
-                        }
-                    })
-                    .catch(error => console.error('Error reordering rules:', error));
-                }
+                onEnd: saveRuleOrder
             });
         } else {
             console.warn('Sortable.js not loaded, skipping rules list initialization');
+        }
+
+        const sortAlphaBtn = document.getElementById('sortAlpha');
+        if (sortAlphaBtn) {
+            sortAlphaBtn.addEventListener('click', () => {
+                const items = Array.from(rulesList.children);
+                items.sort((a, b) => a.getAttribute('data-description').localeCompare(b.getAttribute('data-description')));
+                items.forEach(item => rulesList.appendChild(item));
+                saveRuleOrder();
+            });
+        }
+
+        const sortPointsBtn = document.getElementById('sortPoints');
+        if (sortPointsBtn) {
+            sortPointsBtn.addEventListener('click', () => {
+                const items = Array.from(rulesList.children);
+                items.sort((a, b) => parseInt(b.getAttribute('data-points')) - parseInt(a.getAttribute('data-points')));
+                items.forEach(item => rulesList.appendChild(item));
+                saveRuleOrder();
+            });
         }
     }
 

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 {# admin_manage.html #}
-{# Version: 1.2.44 #}
-{# Note: Enabled rule hover text editing, improved rule layout, and fixed settings link. Compatible with app.py (1.2.108), forms.py (1.2.19), config.py (1.2.6), incentive.html (1.2.45), quick_adjust.html (1.2.18), script.js (1.2.85), style.css (1.2.31), base.html (1.2.21), macros.html (1.2.14), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.6), incentive_service.py (1.2.27), history.html (1.2.6), error.html, init_db.py (1.2.4). #}
+{# Version: 1.2.45 #}
+{# Note: Enabled rule hover text editing, improved rule layout, and fixed settings link. Added CSRF token for rule reordering. Compatible with app.py (1.2.108), forms.py (1.2.19), config.py (1.2.6), incentive.html (1.2.45), quick_adjust.html (1.2.18), script.js (1.2.86), style.css (1.2.31), base.html (1.2.21), macros.html (1.2.14), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.6), incentive_service.py (1.2.27), history.html (1.2.6), error.html, init_db.py (1.2.4). #}
 
 {% block content %}
     {% with messages = get_flashed_messages(with_categories=true) %}
@@ -136,7 +136,12 @@
 
         <div class="rules-container">
             <h2>Rules</h2>
-            {{ macros.render_rule_list(rules, 'rule', 'admin_edit_rule', 'admin_remove_rule', edit_form=True) }}
+            <div class="mb-2">
+                <button type="button" id="sortAlpha" class="btn btn-secondary btn-sm">Sort A-Z</button>
+                <button type="button" id="sortPoints" class="btn btn-secondary btn-sm">Sort by Points</button>
+            </div>
+            {{ macros.render_csrf_token(id='reorder_rules_csrf_token') }}
+            {{ macros.render_rule_list(rules, 'rule', 'admin_edit_rule', 'admin_remove_rule', edit_form=True, list_id='RulesList') }}
         </div>
 
         <div class="add-employee-container">

--- a/templates/history.html
+++ b/templates/history.html
@@ -7,9 +7,9 @@
 {% block content %}
 <h1>Score History</h1>
 <form method="GET" action="{{ url_for('history') }}">
-    {{ macros.render_select_field(name='month_year', id='month_year', label_text='Select Month', options=months, selected_value=selected_month) }}
+    {{ macros.render_select_field({'name': 'month_year', 'errors': []}, id='month_year', label_text='Select Month', options=months, selected_value=selected_month) }}
     {% if days %}
-        {{ macros.render_select_field(name='day', id='day', label_text='Select Day', options=days, selected_value=selected_day) }}
+        {{ macros.render_select_field({'name': 'day', 'errors': []}, id='day', label_text='Select Day', options=days, selected_value=selected_day) }}
     {% endif %}
     {{ macros.render_submit_button('Filter') }}
 </form>

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -94,16 +94,31 @@
 
         <div class="rules-container">
             <h2>Point Conditions</h2>
-            <ul class="list-unstyled">
-                {% for rule in rules %}
-                    <li>
-                        <a href="#" class="quick-adjust-link" data-points="{{ rule.points }}" data-reason="{{ rule.description }}">{{ rule.description }} ({{ rule.points }} points)</a>
-                        {% if rule.details %}
-                            <span class="tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ rule.details }}">?</span>
-                        {% endif %}
-                    </li>
-                {% endfor %}
-            </ul>
+            {% set half = (rules|length + 1) // 2 %}
+            <div class="rules-column">
+                <ul class="list-unstyled">
+                    {% for rule in rules[:half] %}
+                        <li>
+                            <a href="#" class="quick-adjust-link" data-points="{{ rule.points }}" data-reason="{{ rule.description }}">{{ rule.description }} ({{ rule.points }} points)</a>
+                            {% if rule.details %}
+                                <span class="tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ rule.details }}">?</span>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
+            <div class="rules-column">
+                <ul class="list-unstyled">
+                    {% for rule in rules[half:] %}
+                        <li>
+                            <a href="#" class="quick-adjust-link" data-points="{{ rule.points }}" data-reason="{{ rule.description }}">{{ rule.description }} ({{ rule.points }} points)</a>
+                            {% if rule.details %}
+                                <span class="tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ rule.details }}">?</span>
+                            {% endif %}
+                        </li>
+                    {% endfor %}
+                </ul>
+            </div>
         </div>
 
         <div class="pot-container">

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -60,13 +60,13 @@
     <input type="hidden" id="{{ id }}" name="csrf_token" value="{{ csrf_token() }}">
 {% endmacro %}
 
-{% macro render_rule_list(items, type, edit_endpoint, remove_endpoint, edit_form=None) %}
+{% macro render_rule_list(items, type, edit_endpoint, remove_endpoint, edit_form=None, list_id='') %}
     <div class="{{ type }}-container">
-        <ul class="list-unstyled">
+        <ul class="list-unstyled"{% if list_id %} id="{{ list_id }}"{% endif %}>
             {% for item in items %}
-                <li>
+                <li{% if type == 'rule' %} data-description="{{ item.description }}" data-points="{{ item.points }}"{% endif %}>
                     <span>
-                        {{ item.description if type == 'rule' else item.role_name }} 
+                        {{ item.description if type == 'rule' else item.role_name }}
                         ({{ item.points if type == 'rule' else item.percentage }}%)
                         {% if item.details %}
                             <span class="tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ item.details }}">?</span>


### PR DESCRIPTION
## Summary
- Fix history page select fields to prevent template errors
- Show rules in two columns on main page
- Add manual/alpha/points rule sorting with persistence for admins
- Include CSRF token in rule reordering requests

## Testing
- `python -m py_compile app.py incentive_service.py forms.py config.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688fd2e0f5708325bff90ae57c8bd13a