### PR TITLE
Fix duplicate body parameter causing syntax error

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1377,11 +1377,7 @@ document.addEventListener('DOMContentLoaded', function () {
                 headers: {
                     'Content-Type': 'application/x-www-form-urlencoded'
                 },
-
-                body: params
-
-                body: 'order[]=' + order.map(encodeURIComponent).join('&order[]=')
-
+                body: params.toString()
             })
             .then(handleResponse)
             .then(data => {


### PR DESCRIPTION
## Summary
- Remove duplicate `body` property in rule reordering fetch request
- Ensure parameters are serialized before POST

## Testing
- `node --check static/script.js`
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_688fdc3ffc80832597c1b4c1458b9a6b