### PR TITLE
Fix admin workflows and settings page

### DIFF
--- a/app.py
+++ b/app.py
@@ -909,6 +909,9 @@ def admin_update_admin():
                 (new_username, generate_password_hash(new_password), old_username)
             )
         return jsonify({"success": True, "message": f"Admin '{old_username}' updated to '{new_username}'"})
+    except sqlite3.IntegrityError:
+        logging.error("Update admin failed: username '%s' already exists", new_username)
+        return jsonify({"success": False, "message": "Username already exists"}), 400
     except Exception as e:
         logging.error(f"Error in admin_update_admin: {str(e)}\n{traceback.format_exc()}")
         return jsonify({"success": False, "message": "Server error"}), 500

--- a/static/script.js
+++ b/static/script.js
@@ -1122,6 +1122,59 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    const updateAdminForm = document.getElementById('updateAdminForm') || document.getElementById('updateAdminFormUnique');
+    if (updateAdminForm) {
+        updateAdminForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            console.log('Update Admin Form Submitted');
+            const csrfToken = this.querySelector('input[name="csrf_token"]');
+            const oldUsername = this.querySelector('#update_admin_old_username');
+            const newUsername = this.querySelector('#update_admin_new_username');
+            const newPassword = this.querySelector('#update_admin_new_password');
+            if (!oldUsername || !newUsername || !newPassword) {
+                console.error('Update Admin Form Error: Missing fields');
+                alert('All fields are required.');
+                return;
+            }
+            if (!csrfToken || !csrfToken.value.trim()) {
+                console.error('Update Admin Form Error: CSRF Token Missing');
+                alert('Error: CSRF token missing. Please refresh and try again.');
+                return;
+            }
+            const data = {
+                old_username: oldUsername.value,
+                new_username: newUsername.value,
+                new_password: newPassword.value,
+                csrf_token: csrfToken.value
+            };
+            console.log('Update Admin Form Data:', {
+                old_username: data.old_username,
+                new_username: data.new_username,
+                new_password: '****',
+                csrf_token: data.csrf_token
+            });
+            fetch('/admin/update_admin', {
+                method: 'POST',
+                body: new URLSearchParams(data),
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded'
+                }
+            })
+            .then(handleResponse)
+            .then(data => {
+                if (data) {
+                    console.log('Update Admin Response:', data);
+                    alert(data.message);
+                    if (data.success) window.location.reload();
+                }
+            })
+            .catch(error => {
+                console.error('Error updating admin:', error);
+                alert('Failed to update admin. Please try again.');
+            });
+        });
+    }
+
     const removeRuleForms = document.querySelectorAll('.remove-rule-form');
     removeRuleForms.forEach(form => {
         form.addEventListener('submit', function (e) {

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -75,7 +75,7 @@
         <div class="voting-controls-container">
             <h2>Voting Controls</h2>
             {% if not voting_active %}
-                <form action="{{ url_for('start_voting') }}" method="POST">
+                <form id="startVotingForm" action="{{ url_for('start_voting') }}" method="POST">
                     {{ macros.render_csrf_token(id='start_voting_csrf_token') }}
                     {{ macros.render_field(start_voting_form.username, id='start_voting_username', label_text='Username', class='form-control', required=True, value=start_voting_form.username.data if start_voting_form.username.data else '') }}
                     {{ macros.render_field(start_voting_form.password, id='start_voting_password', label_text='Password', class='form-control', type='password', required=True, value=start_voting_form.password.data if start_voting_form.password.data else '') }}
@@ -86,7 +86,7 @@
                     {{ macros.render_csrf_token(id='pause_voting_csrf_token') }}
                     {{ macros.render_submit_button('Pause Voting', class='btn btn-warning') }}
                 </form>
-                <form action="{{ url_for('close_voting') }}" method="POST">
+                <form id="closeVotingForm" action="{{ url_for('close_voting') }}" method="POST">
                     {{ macros.render_csrf_token(id='close_voting_csrf_token') }}
                     {{ macros.render_field(close_voting_form.password, id='close_voting_password', label_text='Admin Password', class='form-control', type='password', required=True, value=close_voting_form.password.data if close_voting_form.password.data else '') }}
                     {{ macros.render_submit_button('Close Voting', class='btn btn-danger') }}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -37,9 +37,15 @@
 
         <h2>Other Settings</h2>
         <form action="{{ url_for('admin_settings') }}" method="POST" id="settingsForm">
-            {{ form.csrf_token }}
-            {{ macros.render_field(name='key', id='settings_key', label_text='Setting Key', class='form-control', required=True) }}
-            {{ macros.render_field(name='value', id='settings_value', label_text='Value', class='form-control', required=True) }}
+            {{ macros.render_csrf_token(id='settings_csrf_token') }}
+            <div class="mb-3">
+                <label for="settings_key" class="form-label">Setting Key</label>
+                <input type="text" name="key" id="settings_key" class="form-control" required>
+            </div>
+            <div class="mb-3">
+                <label for="settings_value" class="form-label">Value</label>
+                <input type="text" name="value" id="settings_value" class="form-control" required>
+            </div>
             {{ macros.render_submit_button('Update Setting', class='btn btn-primary') }}
         </form>
 


### PR DESCRIPTION
## Summary
- Keep admins on dashboard when starting or closing voting by adding form IDs for JS interception
- Fix settings page and add CSRF token and inputs for generic key/value updates
- Improve admin update flow with AJAX handler and better error messaging

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_688fe260d79c8325a74b06185b80f89c