### PR TITLE
feat: make vote limits configurable

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 # forms.py
-# Version: 1.2.20
-# Note: Updated SetPointDecayForm to use standard 'days' field name for multi-select consistency. Compatible with app.py (1.2.108), script.js (1.2.85), config.py (1.2.6), admin_manage.html (1.2.44), incentive.html (1.2.45), quick_adjust.html (1.2.18), style.css (1.2.31), base.html (1.2.21), macros.html (1.2.14), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.6), incentive_service.py (1.2.27), history.html (1.2.6), error.html, init_db.py (1.2.4).
+# Version: 1.2.21
+# Note: Added VoteLimitsForm to allow configuring maximum vote counts via settings. Compatible with app.py (1.2.111), incentive_service.py (1.2.29), settings.html (1.2.8), incentive.html (1.2.48), script.js (1.2.89), init_db.py (1.2.5).
 
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, IntegerField, SelectField, SubmitField, TextAreaField, SelectMultipleField, FloatField
@@ -144,6 +144,12 @@ class VotingThresholdsForm(FlaskForm):
     neg_threshold_3 = IntegerField('Negative Threshold 3 (%)', validators=[DataRequired(), NumberRange(min=0, max=100)])
     neg_points_3 = IntegerField('Negative Points 3', validators=[DataRequired(), NumberRange(min=-100, max=0)])
     submit = SubmitField('Update Voting Thresholds')
+
+class VoteLimitsForm(FlaskForm):
+    max_total_votes = IntegerField('Max Total Votes', validators=[DataRequired(), NumberRange(min=0, max=100)])
+    max_plus_votes = IntegerField('Max Positive Votes', validators=[DataRequired(), NumberRange(min=0, max=100)])
+    max_minus_votes = IntegerField('Max Negative Votes', validators=[DataRequired(), NumberRange(min=0, max=100)])
+    submit = SubmitField('Update Vote Limits')
 
 class QuickAdjustForm(FlaskForm):
     employee_id = SelectField('Employee', validators=[DataRequired()], choices=[])

--- a/init_db.py
+++ b/init_db.py
@@ -1,6 +1,6 @@
 # init_db.py
-# Version: 1.2.4
-# Note: Added migration to include is_master column in admins table to fix sqlite3.OperationalError. Updated master admin to set is_master=1. Ensured idempotent initialization to preserve existing data. Retained dynamic role handling (Master at 0% pot, Supervisor adjustable, max 6 roles). Compatible with app.py (1.2.79), incentive_service.py (1.2.22), forms.py (1.2.7), config.py (1.2.6), admin_manage.html (1.2.32), incentive.html (1.2.28), quick_adjust.html (1.2.11), script.js (1.2.58), style.css (1.2.17), base.html (1.2.21), macros.html (1.2.10), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.5), history.html (1.2.6), error.html. No changes to core database initialization functionality.
+# Version: 1.2.5
+# Note: Included default vote limit settings. Compatible with app.py (1.2.111), incentive_service.py (1.2.29), forms.py (1.2.21), settings.html (1.2.8), incentive.html (1.2.48), script.js (1.2.89).
 
 import sqlite3
 from config import Config
@@ -188,7 +188,10 @@ def initialize_incentive_db():
     default_settings = [
         ('voting_thresholds', '{"positive":[{"threshold":90,"points":10},{"threshold":60,"points":5},{"threshold":25,"points":2}],"negative":[{"threshold":90,"points":-10},{"threshold":60,"points":-5},{"threshold":25,"points":-2}]}'),
         ('program_end_date', ''),
-        ('last_decay_run', '')
+        ('last_decay_run', ''),
+        ('max_total_votes', '3'),
+        ('max_plus_votes', '2'),
+        ('max_minus_votes', '3')
     ]
     cursor.executemany("INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)", default_settings)
 

--- a/static/script.js
+++ b/static/script.js
@@ -1,6 +1,6 @@
 // script.js
-// Version: 1.2.88
-// Note: Updated point decay handling to use standard 'days' field name. Compatible with app.py (1.2.110), forms.py (1.2.20), config.py (1.2.6), admin_manage.html (1.2.45), incentive.html (1.2.45), quick_adjust.html (1.2.18), style.css (1.2.31), base.html (1.2.21), macros.html (1.2.14), start_voting.html (1.2.7), settings.html (1.2.7), admin_login.html (1.2.6), incentive_service.py (1.2.28), history.html (1.2.7), error.html, init_db.py (1.2.4).
+// Version: 1.2.89
+// Note: Voting limits now pulled from server-configured settings. Compatible with app.py (1.2.111), forms.py (1.2.21), incentive_service.py (1.2.29), settings.html (1.2.8), incentive.html (1.2.48), init_db.py (1.2.5).
 
 // Verify Bootstrap Availability
 if (typeof bootstrap === 'undefined') {
@@ -652,19 +652,22 @@ document.addEventListener('DOMContentLoaded', function () {
                 if (value < 0) minusVotes++;
             });
             console.log('Vote Counts:', { plusVotes, minusVotes });
-            if (plusVotes > 2) {
+            const maxPlus = parseInt(document.getElementById('max_plus_votes')?.value || '2');
+            const maxMinus = parseInt(document.getElementById('max_minus_votes')?.value || '3');
+            const maxTotal = parseInt(document.getElementById('max_total_votes')?.value || '3');
+            if (plusVotes > maxPlus) {
                 console.warn('Vote Validation Failed: Too Many Positive Votes');
-                alert('You can only cast up to 2 positive (+1) votes.');
+                alert(`You can only cast up to ${maxPlus} positive (+1) votes.`);
                 return;
             }
-            if (minusVotes > 3) {
+            if (minusVotes > maxMinus) {
                 console.warn('Vote Validation Failed: Too Many Negative Votes');
-                alert('You can only cast up to 3 negative (-1) votes.');
+                alert(`You can only cast up to ${maxMinus} negative (-1) votes.`);
                 return;
             }
-            if (plusVotes + minusVotes > 3) {
+            if (plusVotes + minusVotes > maxTotal) {
                 console.warn('Vote Validation Failed: Too Many Total Votes');
-                alert('You can only cast a maximum of 3 votes total.');
+                alert(`You can only cast a maximum of ${maxTotal} votes total.`);
                 return;
             }
             const formData = new FormData(voteForm);

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 {# incentive.html #}
-{# Version: 1.2.47 #}
-{# Note: Moved quick adjust modal outside admin block so non-admins get login prompt. Compatible with app.py (1.2.107), forms.py (1.2.19), config.py (1.2.6), admin_manage.html (1.2.43), quick_adjust.html (1.2.18), script.js (1.2.83), style.css (1.2.29), base.html (1.2.21), macros.html (1.2.13), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.6), incentive_service.py (1.2.27), history.html (1.2.6), error.html, init_db.py (1.2.4). #}
+{# Version: 1.2.48 #}
+{# Note: Added hidden fields to expose configurable vote limits to client script. Compatible with app.py (1.2.111), forms.py (1.2.21), incentive_service.py (1.2.29), script.js (1.2.89), settings.html (1.2.8), init_db.py (1.2.5). #}
 
 {% block head %}
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" type="text/css">
@@ -60,6 +60,9 @@
                 <form id="voteForm" action="/vote" method="POST" style="display: none;">
                     {{ macros.render_csrf_token(id='vote_csrf_token') }}
                     <input type="hidden" id="hiddenInitials" name="initials" value="">
+                    <input type="hidden" id="max_plus_votes" value="{{ max_plus_votes }}">
+                    <input type="hidden" id="max_minus_votes" value="{{ max_minus_votes }}">
+                    <input type="hidden" id="max_total_votes" value="{{ max_total_votes }}">
                     <table>
                         <thead id="voteTableHead">
                             <tr>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 {# settings.html #}
-{# Version: 1.2.7 #}
-{# Note: Ensured voting thresholds fields prepopulate with current settings and added reporting options for month mode, week start, and auto-open voting. Compatible with app.py (1.2.109), forms.py (1.2.20), config.py (1.2.6), incentive_service.py (1.2.28), admin_manage.html (1.2.45), incentive.html (1.2.45), quick_adjust.html (1.2.18), script.js (1.2.87), style.css (1.2.31), base.html (1.2.21), start_voting.html (1.2.7), macros.html (1.2.14), admin_login.html (1.2.6). #}
+{# Version: 1.2.8 #}
+{# Note: Added form for configuring vote limits. Compatible with app.py (1.2.111), forms.py (1.2.21), incentive_service.py (1.2.29), incentive.html (1.2.48), script.js (1.2.89), init_db.py (1.2.5). #}
 
 {% block content %}
 
@@ -33,6 +33,15 @@
                 </div>
             </div>
             {{ macros.render_submit_button('Update Voting Thresholds', class='btn btn-primary') }}
+        </form>
+        
+        <h2>Vote Limits</h2>
+        <form action="{{ url_for('admin_settings') }}" method="POST" id="voteLimitsForm">
+            {{ vote_limits_form.csrf_token }}
+            {{ macros.render_field(vote_limits_form.max_total_votes, id='max_total_votes', label_text='Max Total Votes', class='form-control', type='number', required=True, value=vote_limits_form.max_total_votes.data) }}
+            {{ macros.render_field(vote_limits_form.max_plus_votes, id='max_plus_votes_limit', label_text='Max Positive Votes', class='form-control', type='number', required=True, value=vote_limits_form.max_plus_votes.data) }}
+            {{ macros.render_field(vote_limits_form.max_minus_votes, id='max_minus_votes_limit', label_text='Max Negative Votes', class='form-control', type='number', required=True, value=vote_limits_form.max_minus_votes.data) }}
+            {{ macros.render_submit_button('Update Vote Limits', class='btn btn-primary') }}
         </form>
 
         <h2>Reporting Settings</h2>


### PR DESCRIPTION
## Summary
- add VoteLimitsForm and settings UI for configuring max total, positive, and negative votes
- enforce configurable vote limits in cast_votes and client-side JS
- seed database with default vote limit settings

## Testing
- `python -m py_compile app.py forms.py incentive_service.py init_db.py`


------
https://chatgpt.com/codex/tasks/task_e_6890df99ad98832580eda647fb020601