### PR TITLE
fix: apply vote points immediately and add session summaries

### DIFF
--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -123,7 +123,35 @@
         {% if is_master %}
             <div class="voting-results-container">
                 <h2>Detailed Voting Results</h2>
+                <select id="sessionSelect" class="form-control mb-3" onchange="window.location.href='/admin?session_id=' + this.value">
+                    {% for sess in sessions %}
+                        <option value="{{ sess.session_id }}" {% if sess.session_id == selected_session_id %}selected{% endif %}>
+                            Session {{ sess.session_id }} ({{ sess.start_time }}{% if sess.end_time %} - {{ sess.end_time }}{% endif %})
+                        </option>
+                    {% endfor %}
+                </select>
                 {{ macros.render_voting_results(voting_results, is_admin=True) }}
+                <h3>Totals</h3>
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>Recipient</th>
+                            <th>Plus Votes</th>
+                            <th>Minus Votes</th>
+                            <th>Points</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        {% for row in vote_totals %}
+                            <tr>
+                                <td>{{ row.recipient_name }}</td>
+                                <td>{{ row.plus }}</td>
+                                <td>{{ row.minus }}</td>
+                                <td>{{ row.points }}</td>
+                            </tr>
+                        {% endfor %}
+                    </tbody>
+                </table>
             </div>
         {% endif %}
 

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -107,7 +107,6 @@
                     <th>Recipient</th>
                     <th>Vote</th>
                     <th>Date</th>
-                    <th>Points</th>
                 {% else %}
                     <th>Week</th>
                     <th>Recipient</th>
@@ -125,7 +124,6 @@
                         <td>{{ result.recipient_name }}</td>
                         <td class="{% if result.vote_value > 0 %}vote-positive{% else %}vote-negative{% endif %}">{{ result.vote_value }}</td>
                         <td>{{ result.vote_date }}</td>
-                        <td>{{ result.points }}</td>
                     {% else %}
                         <td>{{ result.week_number }}</td>
                         <td>{{ result.recipient_name }}</td>


### PR DESCRIPTION
## Summary
- Apply vote values directly to employee scores and log each vote in history
- Streamline voting session closure to store summary counts without score changes
- Add master-only voting session selector with per-session vote totals and detailed history

## Testing
- `python -m py_compile app.py incentive_service.py`

------
https://chatgpt.com/codex/tasks/task_e_6890e70b13a0832599dc29ec2ddf5dea