### PR TITLE
Add role weight management UI and voter-based percentages

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,7 +258,18 @@ Points awarded/deducted based on thresholds in settings (see above).
 Points are applied after a session closes when an employee receives a
 percentage of the total available weighted vote points that meets a
 configured threshold. Role vote weights can be adjusted via the
-`role_vote_weights` setting.
+`role_vote_weights` setting. The setting stores a JSON object mapping
+role names to numeric weights, for example:
+
+```
+{"Driver": 1, "Laborer": 1, "Supervisor": 2, "Master": 3}
+```
+
+By default, regular employees carry a weight of 1, supervisors 2, and the
+master role 3. Any role not listed defaults to 1. During session close,
+each vote's weight is divided by the number of employees who participated
+in the session, so weighted votes from supervisors or the master can push
+an individual's percentage above 100%.
 
 Voting session management:
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -44,6 +44,30 @@
             {{ macros.render_submit_button('Update Vote Limits', class='btn btn-primary') }}
         </form>
 
+        <h2>Role Vote Weights</h2>
+        <form action="{{ url_for('admin_settings') }}" method="POST" id="roleWeightsForm">
+            {{ macros.render_csrf_token(id='role_weights_csrf_token') }}
+            <table class="table">
+                <thead>
+                    <tr>
+                        <th>Role</th>
+                        <th>Weight</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for role in roles %}
+                    <tr>
+                        <td>{{ role }}</td>
+                        <td>
+                            <input type="number" step="0.1" min="0" name="role_weight_{{ role }}" class="form-control" value="{{ role_weights.get(role, 1) }}">
+                        </td>
+                    </tr>
+                    {% endfor %}
+                </tbody>
+            </table>
+            {{ macros.render_submit_button('Update Role Weights', class='btn btn-primary') }}
+        </form>
+
         <h2>Reporting Settings</h2>
         <form action="{{ url_for('admin_settings') }}" method="POST" id="reportingSettingsForm">
             {{ macros.render_csrf_token(id='reporting_settings_csrf_token') }}


### PR DESCRIPTION
## Summary
- add editable role vote weights section to settings page with default weights (Employee 1, Supervisor 2, Master 3)
- support saving and loading role vote weights in admin settings
- base voting percentages on number of voters and apply default role weights during session close
- document role_vote_weights format and behavior

## Testing
- `python -m py_compile app.py incentive_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6890f67b2ee08325853c281acd427f3a