### PR TITLE
Fix duplicate CSRF token IDs and date input warnings

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -34,7 +34,7 @@
                         </li>
                         <li class="nav-item">
                             <form action="{{ url_for('admin_logout') }}" method="POST">
-                                {{ logout_form.csrf_token }}
+                                {{ logout_form.csrf_token(id='logout_csrf_token') }}
                                 {{ macros.render_submit_button('Logout', class='btn btn-link nav-link') }}
                             </form>
                         </li>

--- a/templates/history.html
+++ b/templates/history.html
@@ -7,8 +7,8 @@
 {% block content %}
 <h1>Score History</h1>
 <form method="GET" action="{{ url_for('history') }}">
-    {{ macros.render_field({'name': 'start_date', 'errors': []}, id='start_date', label_text='Start Date', type='date', value=start_date|default('')) }}
-    {{ macros.render_field({'name': 'end_date', 'errors': []}, id='end_date', label_text='End Date', type='date', value=end_date|default('')) }}
+    {{ macros.render_field({'name': 'start_date', 'errors': []}, id='start_date', label_text='Start Date', type='date', value=start_date or '') }}
+    {{ macros.render_field({'name': 'end_date', 'errors': []}, id='end_date', label_text='End Date', type='date', value=end_date or '') }}
     {{ macros.render_select_field({'name': 'employee_id', 'errors': []}, id='employee_id', label_text='Select Employee', options=employees, selected_value=selected_employee) }}
     {{ macros.render_submit_button('Filter') }}
 </form>

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -11,7 +11,7 @@
     {% if is_master %}
         <h2>Voting Thresholds</h2>
         <form action="{{ url_for('admin_settings') }}" method="POST" id="votingThresholdsForm">
-            {{ thresholds_form.csrf_token }}
+            {{ thresholds_form.csrf_token(id='thresholds_csrf_token') }}
             <div class="row">
                 <div class="col-md-6">
                     <h3>Positive Thresholds</h3>
@@ -37,7 +37,7 @@
         
         <h2>Vote Limits</h2>
         <form action="{{ url_for('admin_settings') }}" method="POST" id="voteLimitsForm">
-            {{ vote_limits_form.csrf_token }}
+            {{ vote_limits_form.csrf_token(id='vote_limits_csrf_token') }}
             {{ macros.render_field(vote_limits_form.max_total_votes, id='max_total_votes', label_text='Max Total Votes', class='form-control', type='number', required=True, value=vote_limits_form.max_total_votes.data) }}
             {{ macros.render_field(vote_limits_form.max_plus_votes, id='max_plus_votes_limit', label_text='Max Positive Votes', class='form-control', type='number', required=True, value=vote_limits_form.max_plus_votes.data) }}
             {{ macros.render_field(vote_limits_form.max_minus_votes, id='max_minus_votes_limit', label_text='Max Negative Votes', class='form-control', type='number', required=True, value=vote_limits_form.max_minus_votes.data) }}


### PR DESCRIPTION
## Summary
- Avoid invalid `None` values in history filters by defaulting to blank dates
- Assign unique CSRF token IDs on settings and logout forms to remove DOM warnings

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689104abb1c483259531303c1bc516b0