### PR TITLE
Improve quick adjust UX and admin controls

### DIFF
--- a/config.py
+++ b/config.py
@@ -16,3 +16,5 @@ class Config:
 
     # Vote code for session validation
     VOTE_CODE = "A1RentIt2025"
+
+    ADMIN_SECTIONS = ['rules', 'manage_roles']

--- a/incentive_service.py
+++ b/incentive_service.py
@@ -904,6 +904,11 @@ def get_settings(conn):
         if 'role_vote_weights' not in settings:
             set_settings(conn, 'role_vote_weights', '{}')
             settings['role_vote_weights'] = '{}'
+        for section in Config.ADMIN_SECTIONS:
+            key = f'allow_section_{section}'
+            if key not in settings:
+                set_settings(conn, key, '0')
+                settings[key] = '0'
         return settings
     except sqlite3.OperationalError as e:
         if "no such table: settings" in str(e):

--- a/init_db.py
+++ b/init_db.py
@@ -193,6 +193,7 @@ def initialize_incentive_db():
         ('max_plus_votes', '2'),
         ('max_minus_votes', '3')
     ]
+    default_settings.extend([(f'allow_section_{section}', '0') for section in Config.ADMIN_SECTIONS])
     cursor.executemany("INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)", default_settings)
 
     conn.commit()

--- a/static/style.css
+++ b/static/style.css
@@ -350,6 +350,21 @@ a.rule-link:hover {
     border-color: #D4AF37 transparent transparent transparent;
 }
 
+.quick-adjust-link {
+    display: block;
+    padding: 8px;
+    margin: 6px 0;
+    color: #D4AF37;
+    text-decoration: none;
+    border-radius: 6px;
+    transition: background 0.2s ease, color 0.2s ease;
+}
+
+.quick-adjust-link:hover {
+    background: #D4AF37;
+    color: #000000;
+}
+
 div.pot-container {
     display: flex;
     justify-content: space-between;
@@ -373,6 +388,17 @@ div.pot-column h3 {
     color: #D4AF37;
     background: #000000;
 }
+
+.admin-dashboard .rules-container,
+.admin-dashboard .manage-roles-container {
+    display: block;
+}
+
+.admin-dashboard .section-toggle {
+    text-align: right;
+    margin-bottom: 10px;
+}
+
 
 label.form-label {
     color: #D4AF37;

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -18,7 +18,7 @@
 
     <h1>Admin Dashboard</h1>
 
-    <div class="container">
+    <div class="container admin-dashboard">
         <div class="payouts-container">
             <h2>Employee Payouts</h2>
             <table class="table table-striped">
@@ -197,7 +197,18 @@
             </form>
         </div>
 
+        {% if is_master or section_permissions['rules'] %}
         <div class="rules-container">
+            {% if is_master %}
+            <form action="{{ url_for('admin_toggle_section') }}" method="POST" class="section-toggle">
+                {{ macros.render_csrf_token(id='toggle_csrf_rules') }}
+                <input type="hidden" name="section" value="rules">
+                <div class="form-check form-switch">
+                    <input class="form-check-input" type="checkbox" id="toggle_rules" name="allow" {% if section_permissions['rules'] %}checked{% endif %} onchange="this.form.submit()">
+                    <label class="form-check-label" for="toggle_rules">Allow other admins</label>
+                </div>
+            </form>
+            {% endif %}
             <h2>Rules</h2>
             <div class="mb-2">
                 <button type="button" id="sortAlpha" class="btn btn-secondary btn-sm">Sort A-Z</button>
@@ -208,6 +219,7 @@
 
             {{ macros.render_rule_list(rules, 'rule', 'admin_edit_rule', 'admin_remove_rule', edit_form=True, list_id='RulesList') }}
         </div>
+        {% endif %}
 
         <div class="add-employee-container">
             <h2>Add Employee</h2>
@@ -258,8 +270,18 @@
             </form>
         </div>
 
-        {% if is_master %}
+        {% if is_master or section_permissions['manage_roles'] %}
             <div class="manage-roles-container">
+                {% if is_master %}
+                <form action="{{ url_for('admin_toggle_section') }}" method="POST" class="section-toggle">
+                    {{ macros.render_csrf_token(id='toggle_csrf_manage_roles') }}
+                    <input type="hidden" name="section" value="manage_roles">
+                    <div class="form-check form-switch">
+                        <input class="form-check-input" type="checkbox" id="toggle_manage_roles" name="allow" {% if section_permissions['manage_roles'] %}checked{% endif %} onchange="this.form.submit()">
+                        <label class="form-check-label" for="toggle_manage_roles">Allow other admins</label>
+                    </div>
+                </form>
+                {% endif %}
                 <h2>Manage Roles</h2>
                 <div class="role-sections">
                     <div class="add-role-section">

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -163,14 +163,7 @@
             </div>
         </div>
 
-        {% if is_admin %}
-            <div class="quick-adjust-container">
-                <h2>Quick Adjust Points</h2>
-                {% for rule in rules %}
-                    <a href="#" class="quick-adjust-link" data-points="{{ rule.points }}" data-reason="{{ rule.description }}">{{ rule.description }} ({{ rule.points }} points){% if rule.details %}<span class="tooltip-text" data-bs-toggle="tooltip" data-bs-placement="top" title="{{ rule.details }}">?</span>{% endif %}</a><br>
-                {% endfor %}
-            </div>
-        {% endif %}
+
 
         <div class="voting-results-container">
             <h2>Voting Results</h2>


### PR DESCRIPTION
## Summary
- remove duplicated quick adjust links from incentive page
- restyle point condition links and unsquish admin rule/role panels
- allow master admins to toggle rule and role management visibility for other admins

## Testing
- `python -m py_compile app.py config.py incentive_service.py init_db.py`


------
https://chatgpt.com/codex/tasks/task_e_689112d57f1c8325a59136f176067473