### PR TITLE
Fix vote weighting and add real-time admin status

### DIFF
--- a/incentive_service.py
+++ b/incentive_service.py
@@ -127,8 +127,9 @@ def close_voting_session(conn, admin_id):
     neg_thresholds = sorted(thresholds.get('negative', []), key=lambda x: x['threshold'], reverse=True)
 
     for emp_id, counts in vote_counts.items():
-        plus_percent = (counts["plus_weight"] / total_weight) * 100 if total_weight > 0 else 0
-        minus_percent = (counts["minus_weight"] / total_weight) * 100 if total_weight > 0 else 0
+        emp_total_weight = counts["plus_weight"] + counts["minus_weight"]
+        plus_percent = (counts["plus_weight"] / emp_total_weight) * 100 if emp_total_weight > 0 else 0
+        minus_percent = (counts["minus_weight"] / emp_total_weight) * 100 if emp_total_weight > 0 else 0
 
         points_awarded = 0
         for t in pos_thresholds:

--- a/static/script.js
+++ b/static/script.js
@@ -1621,6 +1621,41 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    // Real-time Voting Status
+    const votingStatusBody = document.getElementById('votingStatusBody');
+    if (votingStatusBody) {
+        function refreshVotingStatus() {
+            fetch('/voting_status')
+                .then(handleResponse)
+                .then(data => {
+                    if (!data || !data.success) return;
+                    votingStatusBody.innerHTML = '';
+                    if (!data.status.length) {
+                        const row = document.createElement('tr');
+                        const cell = document.createElement('td');
+                        cell.colSpan = 2;
+                        cell.textContent = 'No voting status available';
+                        row.appendChild(cell);
+                        votingStatusBody.appendChild(row);
+                        return;
+                    }
+                    data.status.forEach(item => {
+                        const row = document.createElement('tr');
+                        const initTd = document.createElement('td');
+                        initTd.textContent = item.initials;
+                        const votedTd = document.createElement('td');
+                        votedTd.textContent = item.voted ? 'Yes' : 'No';
+                        row.appendChild(initTd);
+                        row.appendChild(votedTd);
+                        votingStatusBody.appendChild(row);
+                    });
+                })
+                .catch(err => console.error('Error fetching voting status:', err));
+        }
+        refreshVotingStatus();
+        setInterval(refreshVotingStatus, 5000);
+    }
+
     // Modal event listeners for aria-hidden fix
     const quickAdjustModal = document.getElementById('quickAdjustModal');
     if (quickAdjustModal) {

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -107,7 +107,7 @@
                         <th>Voted</th>
                     </tr>
                 </thead>
-                <tbody>
+                <tbody id="votingStatusBody">
                     {% for status in voting_status %}
                         <tr>
                             <td>{{ status.initials }}</td>


### PR DESCRIPTION
## Summary
- compute vote percentages per employee to award positive or negative points correctly
- expose `/voting_status` endpoint and auto-refresh table on admin dashboard

## Testing
- `python -m py_compile incentive_service.py app.py`
- `node --check static/script.js`


------
https://chatgpt.com/codex/tasks/task_e_68911c82c06c83259b4b6987162c7609