### PR TITLE
Invalidate data cache after quick adjustments

### DIFF
--- a/app.py
+++ b/app.py
@@ -796,6 +796,9 @@ def admin_quick_adjust_points():
                 logging.error("Quick adjust failed: %s", message)
                 return jsonify({"success": False, "message": message}), 400
             conn.commit()
+        global _data_cache, _cache_timestamp
+        _data_cache = None
+        _cache_timestamp = None
         logging.debug(f"Route /admin/quick_adjust_points took {time.time() - start_time:.2f} seconds")
         return jsonify({"success": True, "message": f"Adjusted {points} points for employee {employee_id}"})
     except Exception as e:


### PR DESCRIPTION
## Summary
- Reset `_data_cache` and `_cache_timestamp` after quick point adjustments to ensure fresh `/data` responses.

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689167835ab88325bdb07cce640e22ef