### PR TITLE
Prevent multiple votes per session

### DIFF
--- a/init_db.py
+++ b/init_db.py
@@ -50,6 +50,16 @@ def initialize_incentive_db():
         )
     """)
 
+    # Track which employees have voted in each session
+    cursor.execute("""
+        CREATE TABLE IF NOT EXISTS vote_participants (
+            session_id INTEGER,
+            voter_initials TEXT,
+            PRIMARY KEY (session_id, voter_initials),
+            FOREIGN KEY(session_id) REFERENCES voting_sessions(session_id)
+        )
+    """)
+
     # Create admins table
     cursor.execute("""
         CREATE TABLE IF NOT EXISTS admins (


### PR DESCRIPTION
## Summary
- Track voting participants in a new `vote_participants` table
- Reject duplicate ballots in `cast_votes` via session-based tracking
- Update vote checking endpoint to consult session voters

## Testing
- `python -m py_compile app.py incentive_service.py init_db.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689169c2fb708325a7c4cdafad4b6ba9