### PR TITLE
Fix voting results points and admin status

### DIFF
--- a/app.py
+++ b/app.py
@@ -506,14 +506,24 @@ def admin():
                     ).fetchall()
                     raw_votes = [dict(row) for row in raw_vote_rows]
             # Voting status
-            active_session = conn.execute("SELECT start_time FROM voting_sessions WHERE end_time IS NULL").fetchone()
+            active_session = conn.execute("SELECT session_id FROM voting_sessions WHERE end_time IS NULL").fetchone()
             voted_initials = set()
             if active_session:
+                conn.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS vote_participants (
+                        session_id INTEGER,
+                        voter_initials TEXT,
+                        PRIMARY KEY (session_id, voter_initials),
+                        FOREIGN KEY(session_id) REFERENCES voting_sessions(session_id)
+                    )
+                    """
+                )
                 voted_initials = set(
                     row["voter_initials"].lower()
                     for row in conn.execute(
-                        "SELECT DISTINCT voter_initials FROM votes WHERE vote_date >= ?",
-                        (active_session["start_time"],),
+                        "SELECT voter_initials FROM vote_participants WHERE session_id = ?",
+                        (active_session["session_id"],),
                     ).fetchall()
                 )
             active_employees = [emp for emp in employees if emp["active"] == 1]
@@ -1330,25 +1340,35 @@ def voting_status():
     try:
         with DatabaseConnection() as conn:
             active_session = conn.execute(
-                "SELECT start_time FROM voting_sessions WHERE end_time IS NULL"
+                "SELECT session_id FROM voting_sessions WHERE end_time IS NULL"
             ).fetchone()
             if not active_session:
                 return jsonify({"success": True, "status": []})
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS vote_participants (
+                    session_id INTEGER,
+                    voter_initials TEXT,
+                    PRIMARY KEY (session_id, voter_initials),
+                    FOREIGN KEY(session_id) REFERENCES voting_sessions(session_id)
+                )
+                """
+            )
             voted_initials = set(
                 row["voter_initials"].lower()
                 for row in conn.execute(
-                    "SELECT DISTINCT voter_initials FROM votes WHERE vote_date >= ?",
-                    (active_session["start_time"],),
+                    "SELECT voter_initials FROM vote_participants WHERE session_id = ?",
+                    (active_session["session_id"],),
                 ).fetchall()
             )
             active_emps = conn.execute(
-                "SELECT initials FROM employees WHERE active = 1"
+                "SELECT initials FROM employees WHERE active = 1 AND LOWER(role) != 'master'"
             ).fetchall()
             status = [
                 {"initials": emp["initials"], "voted": emp["initials"].lower() in voted_initials}
                 for emp in active_emps
             ]
-            status.sort(key=lambda x: x["initials"])
+            status.sort(key=lambda x: x["voted"])
         response = jsonify({"success": True, "status": status})
         response.headers["Cache-Control"] = "no-store, no-cache, must-revalidate, max-age=0"
         response.headers["Pragma"] = "no-cache"


### PR DESCRIPTION
## Summary
- ensure voting results use threshold-based points from `voting_results`
- improve realtime voting status for admins by excluding masters and sorting by vote state
- track vote participants to show realtime voting status accurately

## Testing
- `python -m py_compile app.py incentive_service.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6891747b08948325939c7d340e930a97