### PR TITLE
feat: allow dynamic theme and site branding

### DIFF
--- a/incentive_service.py
+++ b/incentive_service.py
@@ -437,6 +437,13 @@ def master_reset_all(conn):
         ("max_total_votes", "3"),
         ("max_plus_votes", "2"),
         ("max_minus_votes", "3"),
+        ("site_name", "A1 Rent-It"),
+        ("site_title", "A1 Rent-It"),
+        ("primary_color", "#D4AF37"),
+        ("secondary_color", "#000000"),
+        ("background_color", "#3A3A3A"),
+        ("surface_color", "#222222"),
+        ("surface_alt_color", "#1A1A1A"),
     ]
     conn.executemany("INSERT INTO settings (key, value) VALUES (?, ?)", default_settings)
     logging.debug(
@@ -913,6 +920,27 @@ def get_settings(conn):
         if 'role_vote_weights' not in settings:
             set_settings(conn, 'role_vote_weights', '{}')
             settings['role_vote_weights'] = '{}'
+        if 'site_name' not in settings:
+            set_settings(conn, 'site_name', 'A1 Rent-It')
+            settings['site_name'] = 'A1 Rent-It'
+        if 'site_title' not in settings:
+            set_settings(conn, 'site_title', 'A1 Rent-It')
+            settings['site_title'] = 'A1 Rent-It'
+        if 'primary_color' not in settings:
+            set_settings(conn, 'primary_color', '#D4AF37')
+            settings['primary_color'] = '#D4AF37'
+        if 'secondary_color' not in settings:
+            set_settings(conn, 'secondary_color', '#000000')
+            settings['secondary_color'] = '#000000'
+        if 'background_color' not in settings:
+            set_settings(conn, 'background_color', '#3A3A3A')
+            settings['background_color'] = '#3A3A3A'
+        if 'surface_color' not in settings:
+            set_settings(conn, 'surface_color', '#222222')
+            settings['surface_color'] = '#222222'
+        if 'surface_alt_color' not in settings:
+            set_settings(conn, 'surface_alt_color', '#1A1A1A')
+            settings['surface_alt_color'] = '#1A1A1A'
         for section in Config.ADMIN_SECTIONS:
             key = f'allow_section_{section}'
             if key not in settings:

--- a/init_db.py
+++ b/init_db.py
@@ -201,7 +201,14 @@ def initialize_incentive_db():
         ('last_decay_run', ''),
         ('max_total_votes', '3'),
         ('max_plus_votes', '2'),
-        ('max_minus_votes', '3')
+        ('max_minus_votes', '3'),
+        ('site_name', 'A1 Rent-It'),
+        ('site_title', 'A1 Rent-It'),
+        ('primary_color', '#D4AF37'),
+        ('secondary_color', '#000000'),
+        ('background_color', '#3A3A3A'),
+        ('surface_color', '#222222'),
+        ('surface_alt_color', '#1A1A1A')
     ]
     default_settings.extend([(f'allow_section_{section}', '0') for section in Config.ADMIN_SECTIONS])
     cursor.executemany("INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)", default_settings)

--- a/static/style.css
+++ b/static/style.css
@@ -1,11 +1,20 @@
 /* style.css */
-/* Version: 1.2.31 */
-/* Note: Added rule-edit-form styling for cleaner rule editing. Compatible with app.py (1.2.108), script.js (1.2.85), forms.py (1.2.19), config.py (1.2.6), admin_manage.html (1.2.44), incentive.html (1.2.45), quick_adjust.html (1.2.18), base.html (1.2.21), macros.html (1.2.14), start_voting.html (1.2.7), settings.html (1.2.6), admin_login.html (1.2.6), incentive_service.py (1.2.27), history.html (1.2.6), error.html, init_db.py (1.2.4). */
+/* Version: 1.3.0 */
+/* Note: Introduced CSS variables for theming to allow runtime color scheme changes. */
+
+:root {
+    --primary-color: #D4AF37;
+    --primary-color-alpha: #D4AF3733;
+    --secondary-color: #000000;
+    --background-color: #3A3A3A;
+    --surface-color: #222222;
+    --surface-alt-color: #1A1A1A;
+}
 
 body {
     font-family: 'Inter', 'Montserrat', Arial, sans-serif;
-    background: #3A3A3A;
-    color: #D4AF37;
+    background: var(--background-color);
+    color: var(--primary-color);
     margin: 0;
     padding: 0;
     font-size: 16px;
@@ -21,7 +30,7 @@ div.container {
     max-width: 1280px;
     margin: 30px auto;
     padding: 30px;
-    background: #222222;
+    background: var(--surface-color);
     border-radius: 12px;
     box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
     position: relative;
@@ -29,14 +38,14 @@ div.container {
 }
 
 .navbar {
-    background-color: #000000;
-    border-bottom: 3px solid #D4AF37;
+    background-color: var(--secondary-color);
+    border-bottom: 3px solid var(--primary-color);
     z-index: 1000;
     padding: 15px 20px;
 }
 
 .navbar-nav .nav-link {
-    color: #D4AF37;
+    color: var(--primary-color);
     font-weight: 600;
     margin-right: 20px;
     transition: color 0.3s ease, transform 0.2s ease;
@@ -54,8 +63,8 @@ div.alert {
     font-weight: 500;
     position: relative;
     z-index: 1000;
-    border: 1px solid #D4AF37;
-    background: #222222;
+    border: 1px solid var(--primary-color);
+    background: var(--surface-color);
 }
 
 div.alert-success {
@@ -70,7 +79,7 @@ div.alert .btn-close {
     position: absolute;
     top: 12px;
     right: 12px;
-    color: #D4AF37;
+    color: var(--primary-color);
     background: none;
     border: none;
     font-size: 1.2em;
@@ -82,8 +91,8 @@ div.alert .btn-close:hover {
 }
 
 h1, h2, h3 {
-    color: #D4AF37;
-    background: #000000;
+    color: var(--primary-color);
+    background: var(--secondary-color);
     padding: 15px 25px;
     border-radius: 10px;
     text-shadow: 1px 1px 2px rgba(212, 175, 55, 0.3);
@@ -110,13 +119,13 @@ h3 {
 }
 
 .nav-tabs {
-    border-bottom: 3px solid #D4AF37;
+    border-bottom: 3px solid var(--primary-color);
 }
 
 .nav-tabs .nav-link {
-    color: #D4AF37;
-    background: #222222;
-    border: 1px solid #D4AF37;
+    color: var(--primary-color);
+    background: var(--surface-color);
+    border: 1px solid var(--primary-color);
     border-radius: 8px 8px 0 0;
     margin-right: 6px;
     font-weight: 600;
@@ -125,14 +134,14 @@ h3 {
 }
 
 .nav-tabs .nav-link:hover {
-    background: #D4AF37;
-    color: #000000;
+    background: var(--primary-color);
+    color: var(--secondary-color);
     transform: translateY(-2px);
 }
 
 .nav-tabs .nav-link.active {
-    background: #D4AF37;
-    color: #000000;
+    background: var(--primary-color);
+    color: var(--secondary-color);
     border-bottom: none;
 }
 
@@ -143,7 +152,7 @@ h3 {
     border-radius: 8px;
     transition: all 0.3s ease;
     box-shadow: 0 3px 8px rgba(212, 175, 55, 0.2);
-    border: 2px solid #D4AF37;
+    border: 2px solid var(--primary-color);
 }
 
 .btn-primary {
@@ -172,7 +181,7 @@ h3 {
 .btn-success {
     background-color: #2ECC71 !important;
     border-color: #2ECC71 !important;
-    color: #000000 !important;
+    color: var(--secondary-color) !important;
 }
 
 .btn-success:hover {
@@ -192,9 +201,9 @@ h3 {
 }
 
 .btn-warning {
-    background-color: #D4AF37 !important;
-    border-color: #D4AF37 !important;
-    color: #000000 !important;
+    background-color: var(--primary-color) !important;
+    border-color: var(--primary-color) !important;
+    color: var(--secondary-color) !important;
 }
 
 .btn-warning:hover {
@@ -214,25 +223,25 @@ h3 {
 }
 
 .table {
-    background: #222222;
+    background: var(--surface-color);
     border-radius: 10px;
     overflow: hidden;
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
     position: relative;
     z-index: 0;
-    color: #D4AF37;
+    color: var(--primary-color);
     font-size: 1.1em;
 }
 
 .table th, .table td {
     vertical-align: middle;
     padding: 15px 20px;
-    border: 1px solid #D4AF37;
+    border: 1px solid var(--primary-color);
 }
 
 .table th {
-    background: #000000;
-    color: #D4AF37;
+    background: var(--secondary-color);
+    color: var(--primary-color);
     font-weight: 600;
 }
 
@@ -241,7 +250,7 @@ table#scoreboard tbody tr {
 }
 
 table#scoreboard tbody tr:hover {
-    background: #D4AF3733 !important;
+    background: var(--primary-color-alpha) !important;
 }
 
 table#scoreboard tbody tr.score-low td {
@@ -250,13 +259,13 @@ table#scoreboard tbody tr.score-low td {
 }
 
 table#scoreboard tbody tr.score-mid td {
-    background-color: #D4AF37 !important;
-    color: #000000 !important;
+    background-color: var(--primary-color) !important;
+    color: var(--secondary-color) !important;
 }
 
 table#scoreboard tbody tr.score-high td {
     background-color: #2ECC71 !important;
-    color: #000000 !important;
+    color: var(--secondary-color) !important;
 }
 
 div.rules-container, div.manage-roles-container {
@@ -265,10 +274,10 @@ div.rules-container, div.manage-roles-container {
     width: 100%;
     margin: 20px 0;
     gap: 20px;
-    background: #00000033;
+    background: var(--secondary-color)33;
     padding: 20px;
     border-radius: 10px;
-    border: 1px solid #D4AF37;
+    border: 1px solid var(--primary-color);
     z-index: 1;
 }
 
@@ -291,8 +300,8 @@ div.rules-column ul {
 div.rules-column li {
     margin-bottom: 12px;
     padding: 12px;
-    background: #222222;
-    border-left: 4px solid #D4AF37;
+    background: var(--surface-color);
+    border-left: 4px solid var(--primary-color);
     border-radius: 8px;
     transition: transform 0.2s ease, box-shadow 0.2s ease;
     display: flex;
@@ -318,7 +327,7 @@ div.rules-column li:hover {
 a.rule-link {
     cursor: pointer;
     text-decoration: underline;
-    color: #D4AF37;
+    color: var(--primary-color);
     flex-grow: 1;
 }
 
@@ -330,16 +339,16 @@ a.rule-link:hover {
     cursor: pointer;
     font-size: 0.8em;
     margin-left: 5px;
-    color: #D4AF37;
+    color: var(--primary-color);
     font-weight: bold;
     line-height: 1;
     vertical-align: super;
 }
 
 .tooltip-inner {
-    background-color: #000000;
-    color: #D4AF37;
-    border: 1px solid #D4AF37;
+    background-color: var(--secondary-color);
+    color: var(--primary-color);
+    border: 1px solid var(--primary-color);
     border-radius: 8px;
     padding: 10px;
     max-width: 300px;
@@ -347,22 +356,22 @@ a.rule-link:hover {
 }
 
 .tooltip .tooltip-arrow::before {
-    border-color: #D4AF37 transparent transparent transparent;
+    border-color: var(--primary-color) transparent transparent transparent;
 }
 
 .quick-adjust-link {
     display: block;
     padding: 8px;
     margin: 6px 0;
-    color: #D4AF37;
+    color: var(--primary-color);
     text-decoration: none;
     border-radius: 6px;
     transition: background 0.2s ease, color 0.2s ease;
 }
 
 .quick-adjust-link:hover {
-    background: #D4AF37;
-    color: #000000;
+    background: var(--primary-color);
+    color: var(--secondary-color);
 }
 
 div.pot-container {
@@ -376,8 +385,8 @@ div.pot-container {
 div.pot-column {
     flex: 1;
     padding: 20px;
-    background: #222222;
-    border: 2px solid #D4AF37;
+    background: var(--surface-color);
+    border: 2px solid var(--primary-color);
     border-radius: 10px;
     box-shadow: 0 3px 8px rgba(0, 0, 0, 0.3);
 }
@@ -385,8 +394,8 @@ div.pot-column {
 div.pot-column h3 {
     margin-top: 0;
     font-size: 1.3em;
-    color: #D4AF37;
-    background: #000000;
+    color: var(--primary-color);
+    background: var(--secondary-color);
 }
 
 .admin-dashboard .rules-container,
@@ -401,21 +410,21 @@ div.pot-column h3 {
 
 
 label.form-label {
-    color: #D4AF37;
+    color: var(--primary-color);
     font-weight: 600;
     margin-bottom: 8px;
     display: block;
 }
 
 input.form-control, select.form-control, textarea.form-control {
-    border: 2px solid #D4AF37;
+    border: 2px solid var(--primary-color);
     border-radius: 8px;
     padding: 12px;
     transition: border-color 0.3s ease, box-shadow 0.3s ease;
     width: 100%;
     box-sizing: border-box;
-    background: #000000;
-    color: #D4AF37;
+    background: var(--secondary-color);
+    color: var(--primary-color);
     font-size: 1.1em;
     pointer-events: auto !important;
     user-select: auto !important;
@@ -439,7 +448,7 @@ textarea.form-control {
     display: block;
     margin-bottom: 5px;
     font-weight: bold;
-    color: #D4AF37;
+    color: var(--primary-color);
 }
 
 .checkbox-container .form-check {
@@ -450,29 +459,29 @@ textarea.form-control {
 .checkbox-container .form-check-input {
     margin-top: 0;
     margin-right: 5px;
-    border: 2px solid #D4AF37;
-    background-color: #000000;
+    border: 2px solid var(--primary-color);
+    background-color: var(--secondary-color);
 }
 
 .checkbox-container .form-check-input:checked {
-    background-color: #D4AF37;
-    border-color: #D4AF37;
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
 }
 
 .checkbox-container .form-check-label {
-    color: #D4AF37;
+    color: var(--primary-color);
 }
 
 #quickAdjustModal .modal-content {
     pointer-events: auto !important;
     z-index: 1100 !important;
-    background: #222222;
-    border: 2px solid #D4AF37;
+    background: var(--surface-color);
+    border: 2px solid var(--primary-color);
     border-radius: 10px;
 }
 
 #quickAdjustModal .form-control:focus {
-    outline: 2px solid #D4AF37;
+    outline: 2px solid var(--primary-color);
     outline-offset: 2px;
     box-shadow: 0 0 8px rgba(212, 175, 55, 0.6);
 }
@@ -482,7 +491,7 @@ textarea.form-control {
 }
 
 #quickAdjustModal .btn-close:focus {
-    outline: 2px solid #D4AF37;
+    outline: 2px solid var(--primary-color);
     outline-offset: 2px;
 }
 
@@ -502,33 +511,33 @@ div.modal-backdrop {
     table-layout: fixed;
     position: relative;
     z-index: 0;
-    background: #222222;
+    background: var(--surface-color);
 }
 
 #voteForm th, #voteForm td, #votingResults th, #votingResults td {
     padding: 15px 20px;
     vertical-align: middle;
-    border: 1px solid #D4AF37;
+    border: 1px solid var(--primary-color);
 }
 
 #voteForm th, #votingResults th {
-    background-color: #000000;
-    color: #D4AF37;
+    background-color: var(--secondary-color);
+    color: var(--primary-color);
     font-weight: 600;
     font-size: 1.1em;
 }
 
 #voteForm td, #votingResults td {
     text-align: left;
-    color: #D4AF37;
+    color: var(--primary-color);
 }
 
 #voteForm tr:nth-child(even), #votingResults tr:nth-child(even) {
-    background-color: #1A1A1A;
+    background-color: var(--surface-alt-color);
 }
 
 #voteForm tr:hover, #votingResults tr:hover {
-    background-color: #D4AF3733;
+    background-color: var(--primary-color-alpha);
 }
 
 #voteForm td:nth-child(n+4) {
@@ -564,8 +573,8 @@ span.text-danger {
     width: 90%;
     max-width: 500px;
     z-index: 1100;
-    background: #222222;
-    border: 2px solid #D4AF37;
+    background: var(--surface-color);
+    border: 2px solid var(--primary-color);
 }
 
 .loading-overlay {
@@ -582,8 +591,8 @@ span.text-danger {
 }
 
 .loading-spinner {
-    border: 5px solid #222222;
-    border-top: 5px solid #D4AF37;
+    border: 5px solid var(--surface-color);
+    border-top: 5px solid var(--primary-color);
     border-radius: 50%;
     width: 40px;
     height: 40px;
@@ -599,8 +608,8 @@ span.badge {
     padding: 6px 12px;
     border-radius: 6px;
     font-weight: 600;
-    background: #D4AF37;
-    color: #000000;
+    background: var(--primary-color);
+    color: var(--secondary-color);
 }
 
 .manage-roles-container .role-sections {
@@ -612,10 +621,10 @@ span.badge {
 .manage-roles-container .add-role-section,
 .manage-roles-container .edit-remove-role-section,
 .manage-roles-container .set-point-decay-section {
-    background: #222222;
+    background: var(--surface-color);
     padding: 20px; /* Increased padding */
     border-radius: 8px;
-    border: 1px solid #D4AF37;
+    border: 1px solid var(--primary-color);
     z-index: 2; /* Ensure sections are above other elements */
 }
 

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,22 +1,32 @@
 {# templates/base.html #}
-{# Version: 1.2.21 #}
-{# Note:Moved style id="dynamicStyles" to head to ensure CSS injection works with script.js. Retained fixes from version 1.2.20 (Sortable.js inclusion). Ensured compatibility with app.py (1.2.50), forms.py (1.2.4), config.py (1.2.5), admin_manage.html (1.2.25), incentive.html (1.2.21), quick_adjust.html (1.2.10), script.js (1.2.34), style.css (1.2.14), start_voting.html (1.2.4), settings.html (1.2.5), admin_login.html (1.2.5), macros.html (1.2.8). No changes to core layout. #}
+{# Version: 1.3.0 #}
+{# Note: Added dynamic theming and site text via settings. #}
 
 <!DOCTYPE html>
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>A1 Rent-It</title>
+    <title>{{ site_title }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <style id="dynamicStyles"></style>
+    <style id="themeVariables">
+        :root {
+            --primary-color: {{ primary_color }};
+            --primary-color-alpha: {{ primary_color }}33;
+            --secondary-color: {{ secondary_color }};
+            --background-color: {{ background_color }};
+            --surface-color: {{ surface_color }};
+            --surface-alt-color: {{ surface_alt_color }};
+        }
+    </style>
 </head>
 <body>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid">
-            <a class="navbar-brand" href="{{ url_for('show_incentive') }}">A1 Rent-It</a>
+            <a class="navbar-brand" href="{{ url_for('show_incentive') }}">{{ site_name }}</a>
             <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarNav" aria-controls="navbarNav" aria-expanded="false" aria-label="Toggle navigation">
                 <span class="navbar-toggler-icon"></span>
             </button>
@@ -64,7 +74,7 @@
     </div>
 
     <footer class="text-center py-3 mt-5">
-        <p>© 2025 A1 Rent-It. All rights reserved.</p>
+        <p>© {{ current_year }} {{ site_name }}. All rights reserved.</p>
     </footer>
 
     <script src="/static/script.js?v={{ import_time }}"></script>

--- a/templates/error.html
+++ b/templates/error.html
@@ -1,21 +1,9 @@
-<!DOCTYPE html>
-<html lang="en">
-<head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Error - A1 Rent-It Incentive Program</title>
-    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v={{ import_time }}">
-    <link rel="icon" href="{{ url_for('static', filename='favicon.ico') }}">
-</head>
-<body>
-    <div class="container">
-        <h1>Error</h1>
-        <div class="alert alert-danger">
-            {{ error|default('An unexpected error occurred. Please try again later.') }}
-        </div>
-        <a href="{{ url_for('show_incentive') }}" class="btn btn-primary">Return to Home</a>
+{% extends "base.html" %}
+{# error.html - Version: 1.3.0 - Simplified to use base layout and theme settings #}
+{% block content %}
+    <h1>Error</h1>
+    <div class="alert alert-danger">
+        {{ error|default('An unexpected error occurred. Please try again later.') }}
     </div>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
-</body>
-</html>
+    <a href="{{ url_for('show_incentive') }}" class="btn btn-primary">Return to Home</a>
+{% endblock %}

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 {# incentive.html #}
-{# Version: 1.2.48 #}
-{# Note: Added hidden fields to expose configurable vote limits to client script. Compatible with app.py (1.2.111), forms.py (1.2.21), incentive_service.py (1.2.29), script.js (1.2.89), settings.html (1.2.8), init_db.py (1.2.5). #}
+{# Version: 1.3.0 #}
+{# Note: Updated heading to use dynamic site name. #}
 
 {% block head %}
     <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" type="text/css">
@@ -20,7 +20,7 @@
         {% endif %}
     {% endwith %}
 
-    <h1>A1 Rent-It Trial Incentive Program</h1>
+    <h1>{{ site_name }} Trial Incentive Program</h1>
 
     <div class="container">
         <div class="scoreboard-container">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 {# settings.html #}
-{# Version: 1.2.8 #}
-{# Note: Added form for configuring vote limits. Compatible with app.py (1.2.111), forms.py (1.2.21), incentive_service.py (1.2.29), incentive.html (1.2.48), script.js (1.2.89), init_db.py (1.2.5). #}
+{# Version: 1.3.0 #}
+{# Note: Added theme, name, and title settings. #}
 
 {% block content %}
 
@@ -96,6 +96,40 @@
                 </select>
             </div>
             {{ macros.render_submit_button('Update Reporting Settings', class='btn btn-primary') }}
+        </form>
+
+        <h2>Theme Settings</h2>
+        <form action="{{ url_for('admin_settings') }}" method="POST" id="themeSettingsForm">
+            {{ macros.render_csrf_token(id='theme_settings_csrf_token') }}
+            <div class="mb-3">
+                <label for="site_name" class="form-label">Site Name</label>
+                <input type="text" name="site_name" id="site_name" class="form-control" value="{{ settings.get('site_name', 'A1 Rent-It') }}">
+            </div>
+            <div class="mb-3">
+                <label for="site_title" class="form-label">Site Title</label>
+                <input type="text" name="site_title" id="site_title" class="form-control" value="{{ settings.get('site_title', 'A1 Rent-It') }}">
+            </div>
+            <div class="mb-3">
+                <label for="primary_color" class="form-label">Primary Color</label>
+                <input type="color" name="primary_color" id="primary_color" class="form-control form-control-color" value="{{ settings.get('primary_color', '#D4AF37') }}">
+            </div>
+            <div class="mb-3">
+                <label for="secondary_color" class="form-label">Secondary Color</label>
+                <input type="color" name="secondary_color" id="secondary_color" class="form-control form-control-color" value="{{ settings.get('secondary_color', '#000000') }}">
+            </div>
+            <div class="mb-3">
+                <label for="background_color" class="form-label">Background Color</label>
+                <input type="color" name="background_color" id="background_color" class="form-control form-control-color" value="{{ settings.get('background_color', '#3A3A3A') }}">
+            </div>
+            <div class="mb-3">
+                <label for="surface_color" class="form-label">Surface Color</label>
+                <input type="color" name="surface_color" id="surface_color" class="form-control form-control-color" value="{{ settings.get('surface_color', '#222222') }}">
+            </div>
+            <div class="mb-3">
+                <label for="surface_alt_color" class="form-label">Alternate Surface Color</label>
+                <input type="color" name="surface_alt_color" id="surface_alt_color" class="form-control form-control-color" value="{{ settings.get('surface_alt_color', '#1A1A1A') }}">
+            </div>
+            <button type="submit" name="theme_settings" class="btn btn-primary">Update Theme</button>
         </form>
 
         <h2>Other Settings</h2>


### PR DESCRIPTION
## Summary
- add theme settings for primary, secondary, background and surface colors
- allow admins to edit site name and title via settings
- apply settings across templates with CSS variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6892580fe6308325a9ebf9afa99bfa65