### PR TITLE
Allow decimal adjustment for pot percentage

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -83,7 +83,7 @@ class DeleteEmployeeForm(FlaskForm):
 
 class UpdatePotForm(FlaskForm):
     sales_dollars = IntegerField('Sales Dollars', validators=[DataRequired(), NumberRange(min=0)])
-    bonus_percent = IntegerField('Bonus % of Sales Amount', validators=[DataRequired(), NumberRange(min=0, max=100)])
+    bonus_percent = FloatField('Bonus % of Sales Amount', validators=[DataRequired(), NumberRange(min=0, max=100)])
     submit = SubmitField('Update Pot')
 
 class UpdatePriorYearSalesForm(FlaskForm):

--- a/static/script.js
+++ b/static/script.js
@@ -1479,8 +1479,8 @@ document.addEventListener('DOMContentLoaded', function () {
             console.log('Update Pot Form Submitted');
             const formData = new FormData(this);
             const data = {};
-            const salesDollars = this.querySelector('#update_pot_sales_dollars').value;
-            const bonusPercent = this.querySelector('#update_pot_bonus_percent').value;
+            const salesDollars = parseFloat(this.querySelector('#update_pot_sales_dollars').value);
+            const bonusPercent = parseFloat(this.querySelector('#update_pot_bonus_percent').value);
             data['sales_dollars'] = salesDollars;
             data['bonus_percent'] = bonusPercent;
             const csrfToken = this.querySelector('input[name="csrf_token"]');

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -277,7 +277,7 @@
             <form id="updatePotFormUnique" action="{{ url_for('admin_update_pot_endpoint') }}" method="POST" class="mb-4">
                 {{ macros.render_csrf_token(id='update_pot_csrf_token') }}
                 {{ macros.render_field(update_pot_form.sales_dollars, id='update_pot_sales_dollars', label_text='Sales Dollars ($)', class='form-control', type='number', required=True, value=update_pot_form.sales_dollars.data if update_pot_form.sales_dollars.data else 100000) }}
-                {{ macros.render_field(update_pot_form.bonus_percent, id='update_pot_bonus_percent', label_text='Bonus Percent (%)', class='form-control', type='number', required=True, value=update_pot_form.bonus_percent.data if update_pot_form.bonus_percent.data else 10) }}
+                {{ macros.render_field(update_pot_form.bonus_percent, id='update_pot_bonus_percent', label_text='Bonus Percent (%)', class='form-control', type='number', step='0.1', required=True, value=update_pot_form.bonus_percent.data if update_pot_form.bonus_percent.data else 10) }}
                 {{ macros.render_submit_button('Update Pot', class='btn btn-primary') }}
             </form>
         </div>

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -128,13 +128,13 @@
             <div class="pot-column">
                 <h3>Current Pot</h3>
                 <p>Sales: ${{ pot_info.sales_dollars|round(2) }}</p>
-                <p>Bonus %: {{ pot_info.bonus_percent }}%</p>
+                <p>Bonus %: {{ pot_info.bonus_percent|round(1) }}%</p>
                 <p>Total Pot: ${{ (pot_info.sales_dollars * pot_info.bonus_percent / 100)|round(2) }}</p>
             </div>
             <div class="pot-column">
                 <h3>Prior Year</h3>
                 <p>Sales: ${{ pot_info.prior_year_sales|round(2) }}</p>
-                <p>Bonus %: {{ pot_info.bonus_percent }}%</p>
+                <p>Bonus %: {{ pot_info.bonus_percent|round(1) }}%</p>
                 <p>Total Pot: ${{ (pot_info.prior_year_sales * pot_info.bonus_percent / 100)|round(2) }}</p>
             </div>
         </div>

--- a/templates/macros.html
+++ b/templates/macros.html
@@ -2,13 +2,13 @@
 # Version: 1.2.14
 # Note: Added rule-edit-form class for cleaner rule editing layout.
 #}
-{% macro render_field(field, id, label_text, class='', type='text', required=False, value='') %}
+{% macro render_field(field, id, label_text, class='', type='text', required=False, value='', step=None) %}
     <div class="mb-3">
         <label for="{{ id }}" class="form-label">{{ label_text }}</label>
         {% if type == 'textarea' %}
             <textarea id="{{ id }}" name="{{ field.name }}" class="{{ class }}" {% if required %}required{% endif %}>{{ value }}</textarea>
         {% else %}
-            <input type="{{ type }}" id="{{ id }}" name="{{ field.name }}" class="{{ class }}" value="{{ value }}" {% if required %}required{% endif %}>
+            <input type="{{ type }}" id="{{ id }}" name="{{ field.name }}" class="{{ class }}" value="{{ value }}" {% if step is not none %}step="{{ step }}"{% endif %} {% if required %}required{% endif %}>
         {% endif %}
         {% if field.errors %}
             <div class="invalid-feedback d-block">


### PR DESCRIPTION
## Summary
- allow bonus percent to be entered as a decimal
- add macro support for numeric step attribute
- show bonus percent rounded to one decimal place

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689262a3c2188325bf699c96d9780ce6