### PR TITLE
Prefill pot and sales forms with current values

### DIFF
--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -276,8 +276,8 @@
             <h2>Update Pot</h2>
             <form id="updatePotFormUnique" action="{{ url_for('admin_update_pot_endpoint') }}" method="POST" class="mb-4">
                 {{ macros.render_csrf_token(id='update_pot_csrf_token') }}
-                {{ macros.render_field(update_pot_form.sales_dollars, id='update_pot_sales_dollars', label_text='Sales Dollars ($)', class='form-control', type='number', required=True, value=update_pot_form.sales_dollars.data if update_pot_form.sales_dollars.data else 100000) }}
-                {{ macros.render_field(update_pot_form.bonus_percent, id='update_pot_bonus_percent', label_text='Bonus Percent (%)', class='form-control', type='number', step='0.1', required=True, value=update_pot_form.bonus_percent.data if update_pot_form.bonus_percent.data else 10) }}
+                {{ macros.render_field(update_pot_form.sales_dollars, id='update_pot_sales_dollars', label_text='Sales Dollars ($)', class='form-control', type='number', required=True, value=update_pot_form.sales_dollars.value) }}
+                {{ macros.render_field(update_pot_form.bonus_percent, id='update_pot_bonus_percent', label_text='Bonus Percent (%)', class='form-control', type='number', step='0.1', required=True, value=update_pot_form.bonus_percent.value) }}
                 {{ macros.render_submit_button('Update Pot', class='btn btn-primary') }}
             </form>
         </div>
@@ -286,7 +286,7 @@
             <h2>Update Prior Year Sales</h2>
             <form id="updatePriorYearSalesFormUnique" action="{{ url_for('admin_update_prior_year_sales') }}" method="POST" class="mb-4">
                 {{ macros.render_csrf_token(id='update_prior_year_sales_csrf_token') }}
-                {{ macros.render_field(update_prior_year_sales_form.prior_year_sales, id='update_prior_year_sales_prior_year_sales', label_text='Prior Year Sales ($)', class='form-control', type='number', required=True, value=update_prior_year_sales_form.prior_year_sales.data if update_prior_year_sales_form.prior_year_sales.data else 50000) }}
+                {{ macros.render_field(update_prior_year_sales_form.prior_year_sales, id='update_prior_year_sales_prior_year_sales', label_text='Prior Year Sales ($)', class='form-control', type='number', required=True, value=update_prior_year_sales_form.prior_year_sales.value) }}
                 {{ macros.render_submit_button('Update Prior Year Sales', class='btn btn-primary') }}
             </form>
         </div>


### PR DESCRIPTION
## Summary
- Ensure pot amount and bonus percent fields populate with current database values
- Show existing prior-year sales amount in its update form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689267b35a9c8325b2a83b76455a9444