### PR TITLE
Add animated scoreboard flair and admin point controls

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1,6 +1,6 @@
 // script.js
-// Version: 1.2.90
-// Note: Added cache-busting for voting status fetch to ensure real-time updates. Compatible with app.py (1.2.112), forms.py (1.2.21), incentive_service.py (1.2.29), settings.html (1.2.8), incentive.html (1.2.48), init_db.py (1.2.5).
+// Version: 1.2.91
+// Note: Bound scoreboard adjust buttons for quick point edits.
 
 // Verify Bootstrap Availability
 if (typeof bootstrap === 'undefined') {
@@ -300,7 +300,12 @@ document.addEventListener('DOMContentLoaded', function () {
     quickAdjustLinks.forEach(link => {
         link.addEventListener('click', handleQuickAdjustClick);
     });
-    console.log('Bound click event to quick-adjust-link elements');
+
+    const scoreAdjustButtons = document.querySelectorAll('.score-adjust');
+    scoreAdjustButtons.forEach(btn => {
+        btn.addEventListener('click', handleQuickAdjustClick);
+    });
+    console.log('Bound click event to quick-adjust-link and score-adjust elements');
 
     // Quick Adjust Form Submission
     if (window.location.pathname === '/') {
@@ -377,7 +382,8 @@ document.addEventListener('DOMContentLoaded', function () {
                         if (data.success) {
                             const modal = bootstrap.Modal.getInstance(document.getElementById('quickAdjustModal'));
                             if (modal) modal.hide();
-                            window.location.reload();
+                            // Force a fresh scoreboard reload to reflect updated points
+                            window.location.href = window.location.pathname + '?_=' + new Date().getTime();
                         }
                     }
                 })

--- a/static/style.css
+++ b/static/style.css
@@ -1,6 +1,6 @@
 /* style.css */
-/* Version: 1.3.0 */
-/* Note: Introduced CSS variables for theming to allow runtime color scheme changes. */
+/* Version: 1.3.1 */
+/* Note: Added scoreboard flair animations and admin adjust styles. */
 
 :root {
     --primary-color: #D4AF37;
@@ -22,7 +22,7 @@ body {
 }
 
 body::after {
-    content: 'v1.2.30';
+    content: 'v1.3.1';
     display: none;
 }
 
@@ -253,9 +253,20 @@ table#scoreboard tbody tr:hover {
     background: var(--primary-color-alpha) !important;
 }
 
+@keyframes pulse-red {
+    0%, 100% { transform: scale(1); }
+    50% { transform: scale(1.05); }
+}
+
+@keyframes glow-green {
+    0%, 100% { box-shadow: 0 0 5px #2ECC71; }
+    50% { box-shadow: 0 0 20px #2ECC71; }
+}
+
 table#scoreboard tbody tr.score-low td {
     background-color: #E74C3C !important;
     color: #FFFFFF !important;
+    animation: pulse-red 1.5s ease-in-out infinite;
 }
 
 table#scoreboard tbody tr.score-mid td {
@@ -266,6 +277,31 @@ table#scoreboard tbody tr.score-mid td {
 table#scoreboard tbody tr.score-high td {
     background-color: #2ECC71 !important;
     color: var(--secondary-color) !important;
+    animation: glow-green 2s ease-in-out infinite;
+}
+
+@keyframes bounce {
+    0%, 20%, 50%, 80%, 100% { transform: translateY(0); }
+    40% { transform: translateY(-10px); }
+    60% { transform: translateY(-5px); }
+}
+
+@keyframes wiggle {
+    0%, 100% { transform: rotate(0deg); }
+    25% { transform: rotate(-5deg); }
+    75% { transform: rotate(5deg); }
+}
+
+span.celebrate {
+    display: inline-block;
+    margin-left: 4px;
+    animation: bounce 2s infinite;
+}
+
+span.encourage {
+    display: inline-block;
+    margin-left: 4px;
+    animation: wiggle 1.5s infinite;
 }
 
 div.rules-container, div.manage-roles-container {

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 {# incentive.html #}
-{# Version: 1.3.0 #}
-{# Note: Updated heading to use dynamic site name. #}
+{# Version: 1.3.1 #}
+{# Note: Added scoreboard animations and admin adjust buttons. #}
 
 {% block head %}
-    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}" type="text/css">
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}?v={{ import_time }}" type="text/css">
 {% endblock %}
 
 {% block content %}
@@ -35,6 +35,7 @@
                         <th>Score</th>
                         <th>Role</th>
                         <th>Payout ($)</th>
+                        {% if session.admin_id %}<th>Adjust</th>{% endif %}
                     </tr>
                 </thead>
                 <tbody>
@@ -42,9 +43,15 @@
                         <tr class="{{ get_score_class(emp.score) }}">
                             <td>{{ emp.employee_id }}</td>
                             <td>{{ emp.name }}</td>
-                            <td>{{ emp.score }}</td>
+                            <td>{{ emp.score }}
+                                {% set score_class = get_score_class(emp.score) %}
+                                {% if score_class == 'score-high' %}<span class="celebrate">🎉</span>{% elif score_class == 'score-low' %}<span class="encourage">💪</span>{% endif %}
+                            </td>
                             <td>{{ emp.role|capitalize }}</td>
                             <td>{% set role_key = role_key_map.get(emp.role|capitalize, emp.role.lower().replace(' ', '_')) %}{{ (emp.score * pot_info[role_key + '_point_value']|round(4))|round(2) if emp.score >= 50 else 0 }}</td>
+                            {% if session.admin_id %}
+                                <td><button type="button" class="btn btn-sm btn-secondary score-adjust" data-employee="{{ emp.employee_id }}" data-reason="Other">Adjust</button></td>
+                            {% endif %}
                         </tr>
                     {% endfor %}
                 </tbody>


### PR DESCRIPTION
## Summary
- Celebrate top performers with bouncing 🎉 and pulsing row effects on the scoreboard.
- Encourage improvements for low scorers and add quick "Adjust" buttons for admins to modify points.
- Bind new buttons to the existing quick adjust modal for streamlined updates.
- Fix admin-only adjust column rendering and bust cache so new flair shows immediately.

## Testing
- `python -m py_compile app.py forms.py incentive_service.py`


------
https://chatgpt.com/codex/tasks/task_e_68928e1fffa88325904931f1d8b50d4b