### PR TITLE
Add casino flair to incentive interface

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -1772,6 +1772,48 @@ document.addEventListener('DOMContentLoaded', function () {
         setInterval(refreshVotingStatus, 5000);
     }
 
+    // Casino-style excitement
+    function playSlotSound() {
+        try {
+            const ctx = new (window.AudioContext || window.webkitAudioContext)();
+            const osc = ctx.createOscillator();
+            const gain = ctx.createGain();
+            osc.type = 'triangle';
+            osc.frequency.setValueAtTime(880, ctx.currentTime);
+            osc.frequency.exponentialRampToValueAtTime(440, ctx.currentTime + 0.5);
+            gain.gain.setValueAtTime(0.4, ctx.currentTime);
+            gain.gain.exponentialRampToValueAtTime(0.001, ctx.currentTime + 0.5);
+            osc.connect(gain).connect(ctx.destination);
+            osc.start();
+            osc.stop(ctx.currentTime + 0.5);
+        } catch (err) {
+            console.error('Audio failed', err);
+        }
+    }
+
+    const fsBtn = document.getElementById('fullscreenBtn');
+    if (fsBtn) {
+        fsBtn.addEventListener('click', function () {
+            const el = document.documentElement;
+            if (el.requestFullscreen) {
+                el.requestFullscreen();
+            } else if (el.webkitRequestFullscreen) {
+                el.webkitRequestFullscreen();
+            }
+            playSlotSound();
+        });
+    }
+
+    const voteFormEl = document.getElementById('voteForm');
+    if (voteFormEl) {
+        voteFormEl.addEventListener('submit', playSlotSound);
+    }
+
+    const historyFormEl = document.querySelector('form[action="/history"]');
+    if (historyFormEl) {
+        historyFormEl.addEventListener('submit', playSlotSound);
+    }
+
     // Modal event listeners for aria-hidden fix
     const quickAdjustModal = document.getElementById('quickAdjustModal');
     if (quickAdjustModal) {

--- a/static/style.css
+++ b/static/style.css
@@ -682,3 +682,43 @@ span.badge {
     .manage-roles-container .role-sections { flex-direction: column; }
     .checkbox-container .form-check { margin-right: 10px; }
 }
+
+/* Casino theme additions */
+.casino-body {
+    background: radial-gradient(circle, #222 0%, #000 100%);
+}
+
+.casino-banner {
+    text-align: center;
+    font-size: 2.5rem;
+    padding: 20px 10px;
+    background: linear-gradient(90deg, #ff0000, #ffff00, #00ff00, #00ffff, #0000ff, #ff00ff, #ff0000);
+    background-size: 400% 100%;
+    color: #fff;
+    animation: casinoLights 5s linear infinite;
+    font-weight: 700;
+    text-shadow: 0 0 10px #fff, 0 0 20px #ff0000, 0 0 30px #ff00ff;
+}
+
+@keyframes casinoLights {
+    0% { background-position: 0% 50%; }
+    100% { background-position: 100% 50%; }
+}
+
+.casino-fs {
+    position: fixed;
+    top: 10px;
+    right: 10px;
+    z-index: 1050;
+}
+
+.casino-table {
+    border: 4px solid #ffeb3b;
+    box-shadow: 0 0 15px #ffeb3b;
+    animation: tablePulse 2s infinite alternate;
+}
+
+@keyframes tablePulse {
+    from { box-shadow: 0 0 5px #ffeb3b; }
+    to { box-shadow: 0 0 25px #ff00ff; }
+}

--- a/templates/base.html
+++ b/templates/base.html
@@ -23,7 +23,8 @@
         }
     </style>
 </head>
-<body>
+<body class="casino-body">
+    <div class="casino-banner">🎰 Welcome to the Incentive Casino 🎰</div>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid">
 
@@ -59,6 +60,7 @@
             </div>
         </div>
     </nav>
+    <button id="fullscreenBtn" class="btn btn-warning casino-fs">Full Screen</button>
 
     <div class="container mt-4">
         {% with messages = get_flashed_messages(with_categories=true) %}

--- a/templates/history.html
+++ b/templates/history.html
@@ -12,7 +12,7 @@
     {{ macros.render_select_field({'name': 'employee_id', 'errors': []}, id='employee_id', label_text='Select Employee', options=employees, selected_value=selected_employee) }}
     {{ macros.render_submit_button('Filter') }}
 </form>
-<table class="table">
+<table id="historyTable" class="table casino-table">
     <thead>
         <tr>
             <th>Employee</th>

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -27,7 +27,7 @@
     <div class="container">
         <div class="scoreboard-container">
             <h2>Scoreboard</h2>
-            <table id="scoreboard" class="table table-striped">
+            <table id="scoreboard" class="table table-striped casino-table">
                 <thead>
                     <tr>
                         <th>ID</th>
@@ -76,7 +76,7 @@
                     <input type="hidden" id="max_plus_votes" value="{{ max_plus_votes }}">
                     <input type="hidden" id="max_minus_votes" value="{{ max_minus_votes }}">
                     <input type="hidden" id="max_total_votes" value="{{ max_total_votes }}">
-                    <table>
+                    <table class="casino-table">
                         <thead id="voteTableHead">
                             <tr>
                                 <th>ID</th>


### PR DESCRIPTION
## Summary
- Add casino banner and fullscreen toggle to base layout
- Style scoreboard, voting, and history tables with flashing casino theme
- Introduce sound effects and fullscreen mode for a more engaging experience

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_6894a6f58e4c83258ff623b53a2caf3c