### PR TITLE
Normalize incentive page form actions

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -681,7 +681,7 @@ document.addEventListener('DOMContentLoaded', function () {
     }
 
     // Scoreboard Update
-    const scoreboardTable = document.querySelector('#scoreboard tbody');
+    const scoreboardTable = document.querySelector('#scoreboardTable tbody');
     if (scoreboardTable) {
         function updateScoreboard() {
             fetch('/data')
@@ -792,7 +792,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     alert(data.message);
                     if (data.success) {
                         voteForm.reset();
-                        document.querySelectorAll('#voteTableBody input[type="radio"]').forEach(radio => {
+                        voteForm.querySelectorAll('input[type="radio"]').forEach(radio => {
                             if (radio.value === "0") radio.checked = true;
                             else radio.checked = false;
                         });

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -86,7 +86,7 @@
                     {{ macros.render_submit_button('Start Voting', id='startVotingBtn', class='btn btn-primary') }}
                 </form>
             {% else %}
-                <form action="{{ url_for('pause_voting') }}" method="POST">
+                <form id="pauseVotingForm" action="{{ url_for('pause_voting') }}" method="POST">
                     {{ macros.render_csrf_token(id='pause_voting_csrf_token') }}
                     {{ macros.render_submit_button('Pause Voting', class='btn btn-warning') }}
                 </form>

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -85,12 +85,12 @@
     {% if voting_active %}
         <div class="container casino-table">
             <h2 class="text-center">Cast Your Vote</h2>
-            <form id="voteInitialsForm" action="/check_vote" method="POST">
+            <form id="voteInitialsForm" action="{{ url_for('check_vote') }}" method="POST">
                 {{ macros.render_csrf_token(id='vote_initials_csrf_token') }}
                 {{ macros.render_field('', id='voterInitials', label_text='Your Initials', class='form-control', required=True, value='') }}
                 {{ macros.render_submit_button('Check Initials', id='checkInitialsBtn', class='btn btn-success') }}
             </form>
-            <form id="voteForm" action="/vote" method="POST" style="display: none;" onsubmit="return playSlotAnimation(event)">
+            <form id="voteForm" action="{{ url_for('vote') }}" method="POST" style="display: none;" onsubmit="return playSlotAnimation(event)">
                 {{ macros.render_csrf_token(id='vote_csrf_token') }}
                 <input type="hidden" id="hiddenInitials" name="initials" value="">
                 <input type="hidden" id="max_plus_votes" value="{{ max_plus_votes }}">
@@ -186,7 +186,7 @@
                         <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
                     </div>
                     <div class="modal-body">
-                        <form id="adjustPointsForm" action="/admin/quick_adjust_points" method="POST">
+                        <form id="adjustPointsForm" action="{{ url_for('admin_quick_adjust_points') }}" method="POST">
                             {{ macros.render_csrf_token(id='adjust_csrf_token') }}
                             {{ macros.render_select_field(adjust_form.employee_id, id='quick_adjust_employee_id', label_text='Employee', options=employee_options, selected_value='', class='form-control') }}
                             {{ macros.render_field(adjust_form.points, id='quick_adjust_points', label_text='Points', class='form-control', type='number', required=True, value=adjust_form.points.data if adjust_form.points.data else '') }}
@@ -218,7 +218,7 @@
 
     <div class="container casino-table">
         <h2 class="text-center">Submit Feedback</h2>
-        <form action="{{ url_for('incentive') }}" method="POST">
+        <form id="feedbackForm" action="{{ url_for('show_incentive') }}" method="POST">
             {{ macros.render_csrf_token(id='feedback_csrf_token') }}
             {{ macros.render_field(feedback_form.comment, id='feedback_comment', label_text='Comment', class='form-control', type='textarea', required=True, value=feedback_form.comment.data if feedback_form.comment.data else '') }}
             {{ macros.render_field(feedback_form.initials, id='feedback_initials', label_text='Initials (Optional)', class='form-control', value=feedback_form.initials.data if feedback_form.initials.data else '') }}


### PR DESCRIPTION
## Summary
- Replace hard-coded incentive page form URLs with `url_for` for vote, quick-adjust, and feedback submissions
- Point feedback form action to `show_incentive` for a valid fallback endpoint

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894e110d9988325962de51bd0d57e74