### PR TITLE
Enable quick adjust modal on rule click for all users

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -291,7 +291,7 @@ document.addEventListener('DOMContentLoaded', function () {
         setTimeout(() => this.classList.remove('btn-clicked'), 500);
         playSlotSound();
         if (typeof bootstrap !== 'undefined') {
-            const modal = new bootstrap.Modal(quickAdjustModal, { backdrop: 'static', keyboard: true, focus: true });
+            const modal = new bootstrap.Modal(quickAdjustModal, { backdrop: 'static', keyboard: false, focus: true });
             quickAdjustModal.removeEventListener('show.bs.modal', handleModalShow);
             quickAdjustModal.removeEventListener('shown.bs.modal', handleModalShown);
             quickAdjustModal.removeEventListener('hidden.bs.modal', handleModalHidden);

--- a/static/style.css
+++ b/static/style.css
@@ -511,7 +511,28 @@ h3 {
 }
 
 .quick-adjust-modal {
-    animation: modalFlash 1.5s infinite, explodeHover 1s infinite;
+    background: var(--surface-color);
+    color: var(--primary-color);
+    border: 2px solid var(--primary-color);
+}
+
+.quick-adjust-modal .modal-header,
+.quick-adjust-modal .modal-footer {
+    background: var(--surface-alt-color);
+    border-color: var(--primary-color);
+}
+
+.rule-item.quick-adjust-link {
+    cursor: pointer;
+}
+
+#quickAdjustModal,
+#quickAdjustModal .modal-dialog,
+#quickAdjustModal .modal-content,
+.modal-backdrop {
+    animation: none !important;
+    transition: none !important;
+    transform: none !important;
 }
 
 @keyframes modalFlash {
@@ -524,12 +545,11 @@ h3 {
     position: fixed;
     bottom: 20px;
     right: 20px;
-    background: var(--surface-color);
+    background: var(--surface-alt-color);
     padding: 15px;
     border: 2px solid var(--primary-color);
-    box-shadow: 0 0 20px var(--primary-color), 0 0 40px var(--neon-glow);
+    box-shadow: 0 0 20px var(--primary-color);
     z-index: 2000;
-    animation: popupBurst 0.5s ease-out, rainbowShift 3s infinite;
 }
 
 .adjustment-banner {

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -121,7 +121,7 @@
         <div class="row">
             <div class="col-md-6">
                 {% for rule in rules[:half] %}
-                    <div class="rule-item">
+                    <div class="rule-item quick-adjust-link" data-points="{{ rule.points }}" data-reason="{{ rule.description }}">
                         {{ rule.description }} ({{ rule.points }} points)
                         {% if rule.details %}
                             <span class="tooltip" data-bs-toggle="tooltip" data-bs-title="{{ rule.details }}">?</span>
@@ -131,7 +131,7 @@
             </div>
             <div class="col-md-6">
                 {% for rule in rules[half:] %}
-                    <div class="rule-item">
+                    <div class="rule-item quick-adjust-link" data-points="{{ rule.points }}" data-reason="{{ rule.description }}">
                         {{ rule.description }} ({{ rule.points }} points)
                         {% if rule.details %}
                             <span class="tooltip" data-bs-toggle="tooltip" data-bs-title="{{ rule.details }}">?</span>
@@ -163,23 +163,32 @@
         </div>
     </div>
 
-    {% if session.admin_id %}
-        <div class="container casino-table">
-            <h2 class="text-center">Quick Adjust Points</h2>
-            <div class="quick-adjust-modal">
-                {{ macros.render_csrf_token(id='adjust_csrf_token') }}
-                {{ macros.render_select_field(adjust_form.employee_id, id='quick_adjust_employee_id', label_text='Employee', options=employee_options, selected_value='', class='form-control') }}
-                {{ macros.render_field(adjust_form.points, id='quick_adjust_points', label_text='Points', class='form-control', type='number', required=True, value=adjust_form.points.data if adjust_form.points.data else '') }}
-                {{ macros.render_select_field(adjust_form.reason, id='quick_adjust_reason', label_text='Reason', options=reason_options, selected_value=adjust_form.reason.data if adjust_form.reason.data else 'Other', class='form-control') }}
-                {{ macros.render_field(adjust_form.notes, id='quick_adjust_notes', label_text='Notes', class='form-control', type='textarea', value=adjust_form.notes.data if adjust_form.notes.data else '') }}
-                {% if not is_admin %}
-                    {{ macros.render_field(adjust_form.username, id='quick_adjust_username', label_text='Username', class='form-control', required=True, value=adjust_form.username.data if adjust_form.username.data else '') }}
-                    {{ macros.render_field(adjust_form.password, id='quick_adjust_password', label_text='Password', class='form-control', type='password', required=True, value=adjust_form.password.data if adjust_form.password.data else '') }}
-                {% endif %}
-                {{ macros.render_submit_button('Adjust Points', class='btn btn-success') }}
+    <div class="modal" id="quickAdjustModal" tabindex="-1" aria-hidden="true" data-bs-backdrop="static" data-bs-keyboard="false">
+        <div class="modal-dialog modal-dialog-centered">
+            <div class="modal-content quick-adjust-modal">
+                <div class="modal-header">
+                    <h5 class="modal-title">Quick Adjust Points</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <form id="adjustPointsForm" action="{{ url_for('admin_quick_adjust_points') }}" method="POST">
+                    <div class="modal-body">
+                        {{ macros.render_csrf_token(id='adjust_csrf_token') }}
+                        {{ macros.render_select_field(adjust_form.employee_id, id='quick_adjust_employee_id', label_text='Employee', options=employee_options, selected_value='', class='form-control') }}
+                        {{ macros.render_field(adjust_form.points, id='quick_adjust_points', label_text='Points', class='form-control', type='number', required=True, value=adjust_form.points.data if adjust_form.points.data else '') }}
+                        {{ macros.render_select_field(adjust_form.reason, id='quick_adjust_reason', label_text='Reason', options=reason_options, selected_value=adjust_form.reason.data if adjust_form.reason.data else 'Other', class='form-control') }}
+                        {{ macros.render_field(adjust_form.notes, id='quick_adjust_notes', label_text='Notes', class='form-control', type='textarea', value=adjust_form.notes.data if adjust_form.notes.data else '') }}
+                        {% if not is_admin %}
+                            {{ macros.render_field(adjust_form.username, id='quick_adjust_username', label_text='Username', class='form-control', required=True, value=adjust_form.username.data if adjust_form.username.data else '') }}
+                            {{ macros.render_field(adjust_form.password, id='quick_adjust_password', label_text='Password', class='form-control', type='password', required=True, value=adjust_form.password.data if adjust_form.password.data else '') }}
+                        {% endif %}
+                    </div>
+                    <div class="modal-footer">
+                        {{ macros.render_submit_button('Adjust Points', class='btn btn-success') }}
+                    </div>
+                </form>
             </div>
         </div>
-    {% endif %}
+    </div>
 
     <div class="container casino-table">
         <h2 class="text-center">Voting Results</h2>

--- a/templates/quick_adjust.html
+++ b/templates/quick_adjust.html
@@ -9,7 +9,7 @@
 
     {% if get_flashed_messages() %}
         {% for category, message in get_flashed_messages(with_categories=true) %}
-            <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+            <div class="alert alert-{{ category }} alert-dismissible show" role="alert">
                 {{ message|safe }}
                 <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
             </div>
@@ -23,7 +23,7 @@
             document.addEventListener('DOMContentLoaded', function() {
                 const quickAdjustModal = document.getElementById('quickAdjustModal');
                 if (quickAdjustModal) {
-                    const modal = new bootstrap.Modal(quickAdjustModal, { backdrop: 'static', keyboard: true, focus: true });
+                    const modal = new bootstrap.Modal(quickAdjustModal, { backdrop: 'static', keyboard: false, focus: true });
                     modal.show();
                     const points = "{{ points|default('') }}";
                     const reason = "{{ reason|default('') }}";


### PR DESCRIPTION
## Summary
- Allow point condition rules to trigger the quick adjust modal for fast score changes
- Render quick adjust modal for both admins and non-admins, including login fields for unauthenticated users
- Add pointer cursor styling for clickable point rules
- Keep the quick adjust popup stationary with Bootstrap static backdrop, keyboard lock, and no animations

## Testing
- `python -m py_compile app.py forms.py incentive_service.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895fd2408dc83258e9a3e80a7cb58b3