### PR TITLE
Fix confetti effect with positioned wrapper

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -211,13 +211,30 @@ function playJackpotSound() {
 }
 
 function createConfetti(row) {
+    // Ensure a dedicated wrapper exists inside a table cell
+    let wrapperCell = row.querySelector('td.confetti-wrapper');
+    if (!wrapperCell) {
+        row.style.position = 'relative';
+        wrapperCell = document.createElement('td');
+        wrapperCell.className = 'confetti-wrapper';
+        wrapperCell.colSpan = row.children.length;
+        row.appendChild(wrapperCell);
+    }
+
+    let wrapper = wrapperCell.querySelector('.confetti-container');
+    if (!wrapper) {
+        wrapper = document.createElement('div');
+        wrapper.className = 'confetti-container';
+        wrapperCell.appendChild(wrapper);
+    }
+
     for (let i = 0; i < 50; i++) {
         const confetti = document.createElement('div');
         confetti.className = 'confetti';
         confetti.style.left = `${Math.random() * 100}%`;
         confetti.style.background = `hsl(${Math.random() * 360}, 100%, 50%)`;
         confetti.style.animationDelay = `${Math.random() * 2}s`;
-        row.appendChild(confetti);
+        wrapper.appendChild(confetti);
         setTimeout(() => confetti.remove(), 5000);
     }
 }

--- a/static/style.css
+++ b/static/style.css
@@ -312,6 +312,7 @@ h3 {
 
 .scoreboard-row {
     transition: all 0.5s ease;
+    position: relative;
 }
 
 .scoreboard-row.score-top {
@@ -442,6 +443,18 @@ h3 {
     100% { transform: translateX(-50%) scale(1); opacity: 1; }
 }
 
+.confetti-wrapper {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    pointer-events: none;
+    border: none;
+    padding: 0;
+    margin: 0;
+}
+
 .confetti-container {
     position: absolute;
     top: 0;
@@ -450,7 +463,7 @@ h3 {
     height: 100%;
     pointer-events: none;
     overflow: hidden;
-    z-index: -1;
+    z-index: 1;
 }
 
 .confetti {


### PR DESCRIPTION
## Summary
- Render scoreboard confetti in a dedicated `<td>` wrapper to keep table markup valid
- Add styling for confetti wrapper and container with proper positioning and z-index
- Make scoreboard rows relative to allow absolute-positioned overlays

## Testing
- `python -m pytest`
- Attempted `npm install -g jsdom` (failed: 403 Forbidden)


------
https://chatgpt.com/codex/tasks/task_e_6896142e9cd483259e5f4a9632305433