### PR TITLE
Highlight low scores with animated coin prompt

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -351,12 +351,16 @@ h3 {
     100% { border: 2px solid var(--primary-color); }
 }
 
-.scoreboard-row.encouraging-row {
+.scoreboard-row.encouraging-row .score-cell {
     position: relative;
 }
 
 .scoreboard-row.encouraging-row .coin-animation {
     position: absolute;
+    left: 100%;
+    margin-left: 5px;
+    top: 50%;
+    transform: translateY(-50%);
     font-size: 1.5em;
     animation: coinSpin 2s infinite, coinBounce 1s infinite alternate;
 }

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -44,7 +44,7 @@
             </thead>
             <tbody>
                 {% for emp in scoreboard %}
-                    <tr class="scoreboard-row {{ 'score-top' if loop.first else 'score-bottom' if emp.score < money_threshold else 'score-mid' }}" data-confetti="{% if loop.first %}true{% endif %}">
+                    <tr class="scoreboard-row {{ 'score-top' if loop.first else ('score-bottom encouraging-row' if emp.score < money_threshold else 'score-mid') }}" data-confetti="{% if loop.first %}true{% endif %}">
                         <td>{{ emp.employee_id }}</td>
                         <td>{{ emp.name }}</td>
                         <td class="score-cell">{{ emp.score }}


### PR DESCRIPTION
## Summary
- Mark low scoring rows with an `encouraging-row` class
- Reposition coin animation so the icon floats beside the score

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689618b3cef08325aa66068369c6ee8e