### PR TITLE
Fix scoreboard and marquee animations

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -779,6 +779,7 @@ document.addEventListener('DOMContentLoaded', function () {
                     scoreboardTable.innerHTML = '';
                     data.scoreboard.forEach((emp, index) => {
                         const scoreClass = getScoreClass(emp.score, index);
+                        const encouragingClass = emp.score < moneyThreshold ? ' encouraging-row' : '';
                         const roleKeyMap = {
                             'Driver': 'driver',
                             'Laborer': 'laborer',
@@ -791,15 +792,21 @@ document.addEventListener('DOMContentLoaded', function () {
                         const pointValue = data.pot_info[roleKey + '_point_value'] || 0;
                         const payout = emp.score < moneyThreshold ? 0 : (emp.score * pointValue).toFixed(2);
                         const confetti = index === 0 ? ' data-confetti="true"' : '';
+                        const iconSpan = index === 0
+                            ? '<span class="strobing-effect">🎉</span>'
+                            : (emp.score < moneyThreshold ? '<span class="coin-animation">💰</span>' : '');
                         const row = `
-                            <tr class="scoreboard-row ${scoreClass}"${confetti}>
+                            <tr class="scoreboard-row ${scoreClass}${encouragingClass}"${confetti}>
                                 <td>${emp.employee_id}</td>
                                 <td>${emp.name}</td>
-                                <td>${emp.score}</td>
+                                <td class="score-cell">${emp.score}${iconSpan}</td>
                                 <td>${emp.role.charAt(0).toUpperCase() + emp.role.slice(1)}</td>
                                 <td>$${payout}</td>
                             </tr>`;
                         scoreboardTable.insertAdjacentHTML('beforeend', row);
+                    });
+                    document.querySelectorAll('.scoreboard-row[data-confetti="true"]').forEach(row => {
+                        createConfetti(row);
                     });
                 })
                 .catch(error => {

--- a/static/style.css
+++ b/static/style.css
@@ -531,6 +531,29 @@ h3 {
     text-shadow: 0 0 10px #fff, 0 0 20px #ff0000, 0 0 30px #ff00ff, 0 0 40px #00ff00;
 }
 
+/* Scrolling marquee for top performer banner */
+.top-performer-marquee {
+    overflow: hidden;
+    white-space: nowrap;
+    background: var(--rainbow-gradient);
+    background-size: 400% 100%;
+    color: #fff;
+    padding: 10px;
+    font-weight: 700;
+    text-shadow: 0 0 10px #fff, 0 0 20px #ff0000, 0 0 30px #ff00ff, 0 0 40px #00ff00;
+}
+
+.top-performer-marquee span {
+    display: inline-block;
+    padding-left: 100%;
+    animation: marqueeScroll 15s linear infinite;
+}
+
+@keyframes marqueeScroll {
+    0% { transform: translateX(0); }
+    100% { transform: translateX(-100%); }
+}
+
 @keyframes casinoLights {
     0% { background-position: 0% 50%; }
     100% { background-position: 100% 50%; }

--- a/templates/base.html
+++ b/templates/base.html
@@ -28,8 +28,10 @@
             --money-threshold: {{ money_threshold }};
         }
     </style>
+    {% block head %}{% endblock %}
 </head>
 <body class="casino-body">
+    <canvas id="particleCanvas" class="confetti-container"></canvas>
     <div class="casino-banner">🎰 Welcome to the BTE Incentive Jackpot 🎰</div>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid">

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -4,10 +4,6 @@
 {# Version: 1.3.4 #}
 {# Note: Added confetti bursts for top scores, particle effects in background, and explosive animations on quick adjusts. #}
 
-{% block head %}
-    <canvas id="particleCanvas" class="confetti-container"></canvas>
-{% endblock %}
-
 {% block content %}
     {% with messages = get_flashed_messages(with_categories=true) %}
         {% if messages %}
@@ -26,7 +22,7 @@
     {% if scoreboard and scoreboard|length > 0 %}
         {% set top_performer = scoreboard|sort(attribute='score', reverse=True)|first %}
         <div class="top-performer-marquee">
-            🎰 JACKPOT ALERT! {{ top_performer.name }} Leads with {{ top_performer.score }} Points! 🎰
+            <span>🎰 JACKPOT ALERT! {{ top_performer.name }} Leads with {{ top_performer.score }} Points! 🎰</span>
         </div>
     {% endif %}
 


### PR DESCRIPTION
## Summary
- Ensure particle background renders by adding canvas in base template
- Restore Vegas-style marquee for top performer banner
- Keep scoreboard flair icons during AJAX refresh

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68961a94158c8325ac0f044a581f636c