### PR TITLE
Clean admin UI and add configurable banner

### DIFF
--- a/app.py
+++ b/app.py
@@ -69,6 +69,7 @@ def inject_globals():
         money_threshold=int(settings.get('money_threshold', 50)),
         sound_on=settings.get('sound_on', '1'),
         strobe_mode=settings.get('strobe_mode', 'on'),
+        banner_text=settings.get('banner_text', "JACKPOT TIME! GIVE 'EM THE MONEY! SLOTS SPINNING - WINNERS GRINNING!"),
         current_year=datetime.now().year,
         import_time=int(time.time())
     )
@@ -653,6 +654,7 @@ def admin():
             is_admin=True,
             is_master=session.get("admin_id") == "master",
             import_time=int(time.time()),
+            admin_page=True,
             unread_feedback=unread_feedback,
             feedback=feedback,
             settings=settings,
@@ -1685,6 +1687,7 @@ def admin_settings():
                     set_settings(conn, 'background_color', request.form.get('background_color', '#3A3A3A'))
                     set_settings(conn, 'surface_color', request.form.get('surface_color', '#222222'))
                     set_settings(conn, 'surface_alt_color', request.form.get('surface_alt_color', '#1A1A1A'))
+                    set_settings(conn, 'banner_text', request.form.get('banner_text', "JACKPOT TIME! GIVE 'EM THE MONEY! SLOTS SPINNING - WINNERS GRINNING!"))
                 flash('Theme settings updated', 'success')
                 return redirect(url_for('admin_settings'))
             except Exception as e:
@@ -1755,6 +1758,7 @@ def admin_settings():
             settings=settings,
             is_master=session.get("admin_id") == "master",
             import_time=int(time.time()),
+            admin_page=True,
             form=form,
             thresholds_form=form,
             vote_limits_form=vote_limits_form,

--- a/static/admin.css
+++ b/static/admin.css
@@ -1,0 +1,20 @@
+/* admin.css */
+/* Minimal styles for admin pages to remove flashing and strobing */
+.admin-page * {
+    animation: none !important;
+    transition: none !important;
+    box-shadow: none !important;
+    text-shadow: none !important;
+}
+.admin-page body {
+    background: var(--background-color);
+}
+.admin-page .navbar {
+    background: var(--surface-color);
+}
+.admin-page .container {
+    background: var(--surface-color);
+}
+.admin-page #particleCanvas {
+    display: none;
+}

--- a/static/script.js
+++ b/static/script.js
@@ -1973,4 +1973,74 @@ document.addEventListener('DOMContentLoaded', function () {
             console.log('Removed inert from quickAdjustModal and its elements, focused modal dialog');
         });
     }
+
+    // Admin page collapsible modules
+    if (document.body.classList.contains('admin-page')) {
+        const adminSections = document.querySelectorAll('.admin-dashboard > div');
+        adminSections.forEach((section, idx) => {
+            const header = section.querySelector('h2');
+            if (!header) return;
+            const sectionId = `adminSection${idx}`;
+            const contentWrapper = document.createElement('div');
+            contentWrapper.id = sectionId;
+            contentWrapper.className = 'collapse show mt-3';
+            while (header.nextSibling) {
+                contentWrapper.appendChild(header.nextSibling);
+            }
+            section.appendChild(contentWrapper);
+            const switchDiv = document.createElement('div');
+            switchDiv.className = 'form-check form-switch';
+            const switchInput = document.createElement('input');
+            switchInput.className = 'form-check-input module-toggle';
+            switchInput.type = 'checkbox';
+            switchInput.checked = true;
+            switchInput.setAttribute('data-target', sectionId);
+            switchDiv.appendChild(switchInput);
+            const headerWrapper = document.createElement('div');
+            headerWrapper.className = 'd-flex justify-content-between align-items-center';
+            headerWrapper.appendChild(header);
+            headerWrapper.appendChild(switchDiv);
+            section.insertBefore(headerWrapper, section.firstChild);
+        });
+
+        document.querySelectorAll('body.admin-page h2').forEach((header, idx) => {
+            if (header.closest('.admin-dashboard')) return;
+            const sectionId = `settingsSection${idx}`;
+            const elements = [];
+            let next = header.nextElementSibling;
+            while (next && next.tagName !== 'H2') {
+                elements.push(next);
+                next = next.nextElementSibling;
+            }
+            if (!elements.length) return;
+            const wrapper = document.createElement('div');
+            wrapper.id = sectionId;
+            wrapper.className = 'collapse show mt-3';
+            elements.forEach(el => wrapper.appendChild(el));
+            header.parentNode.insertBefore(wrapper, header.nextSibling);
+            const switchDiv = document.createElement('div');
+            switchDiv.className = 'form-check form-switch';
+            const switchInput = document.createElement('input');
+            switchInput.className = 'form-check-input module-toggle';
+            switchInput.type = 'checkbox';
+            switchInput.checked = true;
+            switchInput.setAttribute('data-target', sectionId);
+            switchDiv.appendChild(switchInput);
+            const headerWrapper = document.createElement('div');
+            headerWrapper.className = 'd-flex justify-content-between align-items-center';
+            header.parentNode.insertBefore(headerWrapper, header);
+            headerWrapper.appendChild(header);
+            headerWrapper.appendChild(switchDiv);
+        });
+
+        document.querySelectorAll('.module-toggle').forEach(toggle => {
+            const target = document.getElementById(toggle.getAttribute('data-target'));
+            if (!target) return;
+            const collapse = new bootstrap.Collapse(target, { toggle: false });
+            toggle.addEventListener('change', () => {
+                if (toggle.checked) collapse.show();
+                else collapse.hide();
+            });
+        });
+    }
 });

--- a/static/style.css
+++ b/static/style.css
@@ -667,7 +667,7 @@ body.strobe {
 
 .score-row-win {
     background: linear-gradient(45deg, gold, red);
-    animation: coinSpin 2s infinite;
+    animation: coinSpin 10s linear infinite;
 }
 
 @keyframes coinSpin {

--- a/templates/base.html
+++ b/templates/base.html
@@ -11,6 +11,9 @@
     <title>{{ site_title }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="{{ url_for('static', filename='style.css') }}?v={{ import_time }}" rel="stylesheet">
+    {% if admin_page %}
+    <link href="{{ url_for('static', filename='admin.css') }}?v={{ import_time }}" rel="stylesheet">
+    {% endif %}
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
     <script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.0/Sortable.min.js"></script>
     <style id="dynamicStyles"></style>
@@ -30,9 +33,9 @@
     </style>
     {% block head %}{% endblock %}
 </head>
-<body class="casino-body {% if strobe_mode == 'on' %}strobe{% endif %}">
+<body class="casino-body {% if admin_page %}admin-page{% endif %} {% if strobe_mode == 'on' %}strobe{% endif %}">
     <canvas id="particleCanvas" class="confetti-container"></canvas>
-    <div class="casino-banner"><marquee>💰 JACKPOT TIME! GIVE 'EM THE MONEY! SLOTS SPINNING - WINNERS GRINNING! 💰</marquee></div>
+    <div class="casino-banner"><marquee>💰 {{ banner_text }} 💰</marquee></div>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">
         <div class="container-fluid">
 

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -120,6 +120,10 @@
                 <input type="text" name="site_title" id="site_title" class="form-control" value="{{ settings.get('site_title', 'A1 Rent-It') }}">
             </div>
             <div class="mb-3">
+                <label for="banner_text" class="form-label">Banner Text</label>
+                <input type="text" name="banner_text" id="banner_text" class="form-control" value="{{ settings.get('banner_text', "JACKPOT TIME! GIVE 'EM THE MONEY! SLOTS SPINNING - WINNERS GRINNING!") }}">
+            </div>
+            <div class="mb-3">
                 <label for="primary_color" class="form-label">Primary Color</label>
                 <input type="color" name="primary_color" id="primary_color" class="form-control form-control-color" value="{{ settings.get('primary_color', '#D4AF37') }}">
             </div>


### PR DESCRIPTION
## Summary
- Add admin-specific stylesheet and collapse toggles for a calmer admin dashboard
- Allow customizing top banner text in settings and show it across the site
- Slow scoreboard winner spin effect to trigger less often

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68962e756bc48325a381d75b1b565dcd