### PR TITLE
Restrict strobe effect to main page and add settings toggle

### DIFF
--- a/app.py
+++ b/app.py
@@ -221,7 +221,8 @@ def show_incentive():
             max_plus_votes=max_plus_votes,
             max_minus_votes=max_minus_votes,
             max_total_votes=max_total_votes,
-            recent_adjustments=recent_adjustments
+            recent_adjustments=recent_adjustments,
+            main_page=True
         )
     except Exception as e:
         logging.error(f"Error in show_incentive: {str(e)}\n{traceback.format_exc()}")
@@ -1688,6 +1689,7 @@ def admin_settings():
                     set_settings(conn, 'surface_color', request.form.get('surface_color', '#222222'))
                     set_settings(conn, 'surface_alt_color', request.form.get('surface_alt_color', '#1A1A1A'))
                     set_settings(conn, 'banner_text', request.form.get('banner_text', "JACKPOT TIME! GIVE 'EM THE MONEY! SLOTS SPINNING - WINNERS GRINNING!"))
+                    set_settings(conn, 'strobe_mode', 'on' if request.form.get('strobe_mode') == 'on' else 'off')
                 flash('Theme settings updated', 'success')
                 return redirect(url_for('admin_settings'))
             except Exception as e:

--- a/templates/base.html
+++ b/templates/base.html
@@ -33,7 +33,7 @@
     </style>
     {% block head %}{% endblock %}
 </head>
-<body class="casino-body {% if admin_page %}admin-page{% endif %} {% if strobe_mode == 'on' %}strobe{% endif %}">
+<body class="casino-body {% if admin_page %}admin-page{% endif %} {% if strobe_mode == 'on' and main_page %}strobe{% endif %}">
     <canvas id="particleCanvas" class="confetti-container"></canvas>
     <div class="casino-banner"><marquee>💰 {{ banner_text }} 💰</marquee></div>
     <nav class="navbar navbar-expand-lg navbar-light bg-light">

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -143,6 +143,10 @@
                 <label for="surface_alt_color" class="form-label">Alternate Surface Color</label>
                 <input type="color" name="surface_alt_color" id="surface_alt_color" class="form-control form-control-color" value="{{ settings.get('surface_alt_color', '#1A1A1A') }}">
             </div>
+            <div class="form-check form-switch mb-3">
+                <input class="form-check-input" type="checkbox" id="strobe_mode" name="strobe_mode" value="on" {% if settings.get('strobe_mode', 'on') == 'on' %}checked{% endif %}>
+                <label class="form-check-label" for="strobe_mode">Enable Strobe Effect on Main Page</label>
+            </div>
             <button type="submit" name="theme_settings" class="btn btn-primary">Update Theme</button>
         </form>
 


### PR DESCRIPTION
## Summary
- Limit strobe effect to only appear on the main incentive page
- Add admin settings toggle to enable or disable strobe effect

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689b3ff998d8832583f12f8530cdb8e8