### PR TITLE
Handle audio playback errors and allow configurable scoreboard timing

### DIFF
--- a/static/script.js
+++ b/static/script.js
@@ -62,9 +62,20 @@ const slotAudio = new Audio('/static/slot-pull.mp3');
 [coinAudio, jackpotAudio, slotAudio].forEach(a => a.volume = 0.5);
 window.jackpotPlayed = false;
 
-function playCoinSound(){ if(soundOn){ coinAudio.currentTime = 0; coinAudio.play(); } }
-function playJackpot(){ if(soundOn){ jackpotAudio.currentTime = 0; jackpotAudio.play(); } }
-function playSlotPull(){ if(soundOn){ slotAudio.currentTime = 0; slotAudio.play(); } }
+function safePlay(audio, label) {
+    try {
+        const playPromise = audio.play();
+        if (playPromise !== undefined) {
+            playPromise.catch(err => console.warn(`${label} playback failed:`, err));
+        }
+    } catch (err) {
+        console.warn(`${label} playback exception:`, err);
+    }
+}
+
+function playCoinSound(){ if(soundOn){ coinAudio.currentTime = 0; safePlay(coinAudio,'coin'); } }
+function playJackpot(){ if(soundOn){ jackpotAudio.currentTime = 0; safePlay(jackpotAudio,'jackpot'); } }
+function playSlotPull(){ if(soundOn){ slotAudio.currentTime = 0; safePlay(slotAudio,'slot'); } }
 
 function rainCoins(){ if (typeof confetti !== 'undefined'){ confetti({ particleCount:100, spread:70, origin:{ y:0.6 } }); } }
 
@@ -755,6 +766,7 @@ document.addEventListener('DOMContentLoaded', function () {
     const scoreboardTable = document.querySelector('#scoreboardTable tbody');
     if (scoreboardTable) {
         const moneyThreshold = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--money-threshold'));
+        const refreshInterval = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--scoreboard-refresh-interval')) || 60000;
         function updateScoreboard() {
             fetch('/data')
                 .then(response => {
@@ -817,7 +829,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         updateScoreboard();
-        setInterval(updateScoreboard, 60000);
+        setInterval(updateScoreboard, refreshInterval);
     }
 
    

--- a/static/style.css
+++ b/static/style.css
@@ -14,6 +14,9 @@
     --score-top-color: #D4AF37;
     --score-mid-color: #FFFFFF;
     --score-bottom-color: #FF6347;
+    --scoreboard-spin-duration: 10s;
+    --scoreboard-spin-iterations: infinite;
+    --scoreboard-refresh-interval: 60000;
 }
 
 body {
@@ -667,7 +670,7 @@ body.strobe {
 
 .score-row-win {
     background: linear-gradient(45deg, gold, red);
-    animation: coinSpin 10s linear infinite;
+    animation: coinSpin var(--scoreboard-spin-duration,10s) linear 0s var(--scoreboard-spin-iterations,infinite);
 }
 
 @keyframes coinSpin {


### PR DESCRIPTION
## Summary
- Guard audio playback with `safePlay` to prevent unhandled NotSupportedError
- Add CSS variables to control scoreboard spin speed, spin iterations, and refresh interval
- Use CSS-driven refresh interval when updating the scoreboard

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b4718220083258c2ed9827137df48