### PR TITLE
Handle audio playback errors and allow configurable scoreboard timing

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,6 +1,6 @@
 # app.py
-# Version: 1.2.113
-# Note: Display recent admin point adjustments on incentive page. Compatible with incentive_service.py (1.2.30), forms.py (1.2.21), settings.html (1.2.8), incentive.html (1.3.2), script.js (1.2.92), init_db.py (1.2.5).
+# Version: 1.2.114
+# Note: Added configurable scoreboard timing settings. Compatible with incentive_service.py (1.2.31), forms.py (1.2.22), settings.html (1.3.1), incentive.html (1.3.2), script.js (1.2.97), init_db.py (1.2.5).
 
 from flask import Flask, render_template, request, jsonify, session, redirect, url_for, send_file, send_from_directory, flash
 from werkzeug.security import check_password_hash, generate_password_hash
@@ -67,6 +67,10 @@ def inject_globals():
         score_mid_color=settings.get('score_mid_color', '#FFFFFF'),
         score_bottom_color=settings.get('score_bottom_color', '#FF6347'),
         money_threshold=int(settings.get('money_threshold', 50)),
+        scoreboard_spin_duration=int(settings.get('scoreboard_spin_duration', 10)),
+        scoreboard_spin_iterations=int(settings.get('scoreboard_spin_iterations', 0)),
+        scoreboard_spin_pause=int(settings.get('scoreboard_spin_pause', 0)),
+        scoreboard_refresh_interval=int(settings.get('scoreboard_refresh_interval', 60)),
         sound_on=settings.get('sound_on', '1'),
         strobe_mode=settings.get('strobe_mode', 'on'),
         banner_text=settings.get('banner_text', "JACKPOT TIME! GIVE 'EM THE MONEY! SLOTS SPINNING - WINNERS GRINNING!"),
@@ -1636,6 +1640,10 @@ def admin_settings():
                     set_settings(conn, 'score_top_color', form.top_color.data)
                     set_settings(conn, 'score_mid_color', form.mid_color.data)
                     set_settings(conn, 'score_bottom_color', form.bottom_color.data)
+                    set_settings(conn, 'scoreboard_spin_duration', str(form.spin_duration.data))
+                    set_settings(conn, 'scoreboard_spin_iterations', str(form.spin_iterations.data))
+                    set_settings(conn, 'scoreboard_spin_pause', str(form.spin_pause.data))
+                    set_settings(conn, 'scoreboard_refresh_interval', str(form.refresh_interval.data))
                 flash('Scoreboard settings updated', 'success')
                 return redirect(url_for('admin_settings'))
             except Exception as e:
@@ -1739,6 +1747,10 @@ def admin_settings():
             scoreboard_form.top_color.data = settings.get('score_top_color', '#D4AF37')
             scoreboard_form.mid_color.data = settings.get('score_mid_color', '#FFFFFF')
             scoreboard_form.bottom_color.data = settings.get('score_bottom_color', '#FF6347')
+            scoreboard_form.spin_duration.data = int(settings.get('scoreboard_spin_duration', 10))
+            scoreboard_form.spin_iterations.data = int(settings.get('scoreboard_spin_iterations', 0))
+            scoreboard_form.spin_pause.data = int(settings.get('scoreboard_spin_pause', 0))
+            scoreboard_form.refresh_interval.data = int(settings.get('scoreboard_refresh_interval', 60))
             roles = [row['role_name'] for row in conn.execute('SELECT role_name FROM roles').fetchall()]
             try:
                 role_weights = json.loads(settings.get('role_vote_weights', '{}'))

--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 # forms.py
-# Version: 1.2.21
-# Note: Added VoteLimitsForm to allow configuring maximum vote counts via settings. Compatible with app.py (1.2.111), incentive_service.py (1.2.29), settings.html (1.2.8), incentive.html (1.2.48), script.js (1.2.89), init_db.py (1.2.5).
+# Version: 1.2.22
+# Note: Added scoreboard timing fields to ScoreboardSettingsForm. Compatible with app.py (1.2.114), incentive_service.py (1.2.31), settings.html (1.3.1), incentive.html (1.3.2), script.js (1.2.97), init_db.py (1.2.5).
 
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, IntegerField, SelectField, SubmitField, TextAreaField, SelectMultipleField, FloatField
@@ -156,6 +156,10 @@ class ScoreboardSettingsForm(FlaskForm):
     top_color = StringField('Top Color', validators=[DataRequired()])
     mid_color = StringField('Middle Color', validators=[DataRequired()])
     bottom_color = StringField('Bottom Color', validators=[DataRequired()])
+    spin_duration = IntegerField('Spin Duration (s)', validators=[DataRequired(), NumberRange(min=1, max=3600)])
+    spin_iterations = IntegerField('Spin Iterations (0=infinite)', validators=[DataRequired(), NumberRange(min=0, max=1000)])
+    spin_pause = IntegerField('Spin Pause (s)', validators=[DataRequired(), NumberRange(min=0, max=3600)])
+    refresh_interval = IntegerField('Refresh Interval (s)', validators=[DataRequired(), NumberRange(min=1, max=3600)])
     submit = SubmitField('Update Scoreboard Settings')
 
 class QuickAdjustForm(FlaskForm):

--- a/incentive_service.py
+++ b/incentive_service.py
@@ -1,6 +1,6 @@
 # incentive_service.py
-# Version: 1.2.30
-# Note: Added helper to fetch recent admin point adjustments. Compatible with app.py (1.2.113), forms.py (1.2.21), settings.html (1.2.8), incentive.html (1.3.2), script.js (1.2.92), init_db.py (1.2.5).
+# Version: 1.2.31
+# Note: Added default scoreboard timing settings. Compatible with app.py (1.2.114), forms.py (1.2.22), settings.html (1.3.1), incentive.html (1.3.2), script.js (1.2.97), init_db.py (1.2.5).
 
 import sqlite3
 from datetime import datetime, timedelta
@@ -973,6 +973,18 @@ def get_settings(conn):
         if 'score_bottom_color' not in settings:
             set_settings(conn, 'score_bottom_color', '#FF6347')
             settings['score_bottom_color'] = '#FF6347'
+        if 'scoreboard_spin_duration' not in settings:
+            set_settings(conn, 'scoreboard_spin_duration', '10')
+            settings['scoreboard_spin_duration'] = '10'
+        if 'scoreboard_spin_iterations' not in settings:
+            set_settings(conn, 'scoreboard_spin_iterations', '0')
+            settings['scoreboard_spin_iterations'] = '0'
+        if 'scoreboard_spin_pause' not in settings:
+            set_settings(conn, 'scoreboard_spin_pause', '0')
+            settings['scoreboard_spin_pause'] = '0'
+        if 'scoreboard_refresh_interval' not in settings:
+            set_settings(conn, 'scoreboard_refresh_interval', '60')
+            settings['scoreboard_refresh_interval'] = '60'
         for section in Config.ADMIN_SECTIONS:
             key = f'allow_section_{section}'
             if key not in settings:

--- a/static/script.js
+++ b/static/script.js
@@ -62,9 +62,20 @@ const slotAudio = new Audio('/static/slot-pull.mp3');
 [coinAudio, jackpotAudio, slotAudio].forEach(a => a.volume = 0.5);
 window.jackpotPlayed = false;
 
-function playCoinSound(){ if(soundOn){ coinAudio.currentTime = 0; coinAudio.play(); } }
-function playJackpot(){ if(soundOn){ jackpotAudio.currentTime = 0; jackpotAudio.play(); } }
-function playSlotPull(){ if(soundOn){ slotAudio.currentTime = 0; slotAudio.play(); } }
+function safePlay(audio, label) {
+    try {
+        const playPromise = audio.play();
+        if (playPromise !== undefined) {
+            playPromise.catch(err => console.warn(`${label} playback failed:`, err));
+        }
+    } catch (err) {
+        console.warn(`${label} playback exception:`, err);
+    }
+}
+
+function playCoinSound(){ if(soundOn){ coinAudio.currentTime = 0; safePlay(coinAudio,'coin'); } }
+function playJackpot(){ if(soundOn){ jackpotAudio.currentTime = 0; safePlay(jackpotAudio,'jackpot'); } }
+function playSlotPull(){ if(soundOn){ slotAudio.currentTime = 0; safePlay(slotAudio,'slot'); } }
 
 function rainCoins(){ if (typeof confetti !== 'undefined'){ confetti({ particleCount:100, spread:70, origin:{ y:0.6 } }); } }
 
@@ -755,6 +766,24 @@ document.addEventListener('DOMContentLoaded', function () {
     const scoreboardTable = document.querySelector('#scoreboardTable tbody');
     if (scoreboardTable) {
         const moneyThreshold = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--money-threshold'));
+        const refreshInterval = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--scoreboard-refresh-interval')) || 60000;
+        const spinPause = parseInt(getComputedStyle(document.documentElement).getPropertyValue('--scoreboard-spin-pause')) || 0;
+        const spinIterationsRaw = getComputedStyle(document.documentElement).getPropertyValue('--scoreboard-spin-iterations').trim();
+        const spinIterations = parseInt(spinIterationsRaw) > 0 ? parseInt(spinIterationsRaw) : Infinity;
+
+        function attachSpinPause(rows) {
+            if (spinPause <= 0 || rows.length === 0) return;
+            let iteration = 0;
+            const controller = rows[0];
+            controller.addEventListener('animationiteration', () => {
+                iteration++;
+                if (iteration >= spinIterations) {
+                    rows.forEach(r => r.style.animationPlayState = 'paused');
+                    iteration = 0;
+                    setTimeout(() => rows.forEach(r => r.style.animationPlayState = 'running'), spinPause * 1000);
+                }
+            });
+        }
         function updateScoreboard() {
             fetch('/data')
                 .then(response => {
@@ -797,8 +826,10 @@ document.addEventListener('DOMContentLoaded', function () {
                                 <td class="${payout > 0 ? 'payout-cell' : ''}">$${payout}</td>
                             </tr>`;
                         scoreboardTable.insertAdjacentHTML('beforeend', row);
-                        if (!window.jackpotPlayed && index < 3) { playJackpot(); window.jackpotPlayed = true; }
+                        if (index < 3 && !window.jackpotPlayed) { playJackpot(); window.jackpotPlayed = true; }
                     });
+                    const topRows = scoreboardTable.querySelectorAll('.score-row-win');
+                    attachSpinPause(topRows);
                     document.querySelectorAll('.scoreboard-row[data-confetti="true"]').forEach(row => {
                         createConfetti(row);
                     });
@@ -817,7 +848,7 @@ document.addEventListener('DOMContentLoaded', function () {
         }
 
         updateScoreboard();
-        setInterval(updateScoreboard, 60000);
+        setInterval(updateScoreboard, refreshInterval);
     }
 
    

--- a/static/style.css
+++ b/static/style.css
@@ -14,6 +14,10 @@
     --score-top-color: #D4AF37;
     --score-mid-color: #FFFFFF;
     --score-bottom-color: #FF6347;
+    --scoreboard-spin-duration: 10s;
+    --scoreboard-spin-iterations: 1;
+    --scoreboard-spin-pause: 0s;
+    --scoreboard-refresh-interval: 60000;
 }
 
 body {
@@ -667,7 +671,8 @@ body.strobe {
 
 .score-row-win {
     background: linear-gradient(45deg, gold, red);
-    animation: coinSpin 10s linear infinite;
+    animation: coinSpin var(--scoreboard-spin-duration,10s) linear infinite;
+    animation-play-state: running;
 }
 
 @keyframes coinSpin {

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,6 +1,6 @@
 {# templates/base.html #}
-{# Version: 1.3.1 #}
-{# Note: Enhanced casino banner with more text shadow and animation, added particle canvas. #}
+{# Version: 1.3.2 #}
+{# Note: Added scoreboard timing variables and enhanced casino banner with particle canvas. #}
 
 {% import "macros.html" as macros %}
 <!DOCTYPE html>
@@ -29,6 +29,10 @@
             --score-mid-color: {{ score_mid_color }};
             --score-bottom-color: {{ score_bottom_color }};
             --money-threshold: {{ money_threshold }};
+            --scoreboard-spin-duration: {{ scoreboard_spin_duration }}s;
+            --scoreboard-spin-iterations: {{ scoreboard_spin_iterations }};
+            --scoreboard-spin-pause: {{ scoreboard_spin_pause }}s;
+            --scoreboard-refresh-interval: {{ scoreboard_refresh_interval * 1000 }};
         }
     </style>
     {% block head %}{% endblock %}

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 {# settings.html #}
-{# Version: 1.3.0 #}
-{# Note: Added theme, name, and title settings. #}
+{# Version: 1.3.1 #}
+{# Note: Added scoreboard timing controls to settings. #}
 
 {% block content %}
 
@@ -51,6 +51,10 @@
             {{ macros.render_field(scoreboard_form.top_color, id='top_color_setting', label_text='Top Color', class='form-control form-control-color', type='color', value=scoreboard_form.top_color.data) }}
             {{ macros.render_field(scoreboard_form.mid_color, id='mid_color_setting', label_text='Middle Color', class='form-control form-control-color', type='color', value=scoreboard_form.mid_color.data) }}
             {{ macros.render_field(scoreboard_form.bottom_color, id='bottom_color_setting', label_text='Bottom Color', class='form-control form-control-color', type='color', value=scoreboard_form.bottom_color.data) }}
+            {{ macros.render_field(scoreboard_form.spin_duration, id='spin_duration_setting', label_text='Spin Duration (s)', class='form-control', type='number', required=True, value=scoreboard_form.spin_duration.data) }}
+            {{ macros.render_field(scoreboard_form.spin_iterations, id='spin_iterations_setting', label_text='Spin Iterations (0=infinite)', class='form-control', type='number', required=True, value=scoreboard_form.spin_iterations.data) }}
+            {{ macros.render_field(scoreboard_form.spin_pause, id='spin_pause_setting', label_text='Spin Pause (s)', class='form-control', type='number', required=True, value=scoreboard_form.spin_pause.data) }}
+            {{ macros.render_field(scoreboard_form.refresh_interval, id='refresh_interval_setting', label_text='Refresh Interval (s)', class='form-control', type='number', required=True, value=scoreboard_form.refresh_interval.data) }}
             {{ macros.render_submit_button('Update Scoreboard Settings', class='btn btn-primary') }}
         </form>
 


### PR DESCRIPTION
## Summary
- Guard audio playback with `safePlay` to prevent unhandled NotSupportedError
- Add CSS variables to control scoreboard spin speed, spin iterations, pause before next spin, and refresh interval
- Expose scoreboard timing controls on the admin settings page and persist them in the database
- Use CSS-driven refresh interval when updating the scoreboard and pause the animation between spin cycles via JS

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_689b4718220083258c2ed9827137df48