### PR TITLE
Add resume and finalize voting session controls

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,13 +1,13 @@
 # app.py
-# Version: 1.2.112
-# Note: Added no-cache headers for real-time voting status. Compatible with incentive_service.py (1.2.29), forms.py (1.2.21), settings.html (1.2.8), incentive.html (1.2.48), script.js (1.2.90), init_db.py (1.2.5).
+# Version: 1.2.113
+# Note: Added resume and finalize voting routes. Compatible with incentive_service.py (1.2.30), forms.py (1.2.22), settings.html (1.2.8), incentive.html (1.2.48), script.js (1.2.92), init_db.py (1.2.5).
 
 from flask import Flask, render_template, request, jsonify, session, redirect, url_for, send_file, send_from_directory, flash
 from werkzeug.security import check_password_hash, generate_password_hash
 from flask_wtf.csrf import CSRFProtect, CSRFError
-from incentive_service import DatabaseConnection, get_scoreboard, start_voting_session, is_voting_active, cast_votes, add_employee, reset_scores, get_history, adjust_points, get_rules, add_rule, edit_rule, remove_rule, get_pot_info, update_pot_info, close_voting_session, pause_voting_session, get_voting_results, master_reset_all, get_roles, add_role, edit_role, remove_role, edit_employee, reorder_rules, retire_employee, reactivate_employee, delete_employee, set_point_decay, get_point_decay, deduct_points_daily, get_latest_voting_results, add_feedback, get_unread_feedback_count, get_feedback, mark_feedback_read, delete_feedback, get_settings, set_settings
+from incentive_service import DatabaseConnection, get_scoreboard, start_voting_session, is_voting_active, cast_votes, add_employee, reset_scores, get_history, adjust_points, get_rules, add_rule, edit_rule, remove_rule, get_pot_info, update_pot_info, close_voting_session, pause_voting_session, resume_voting_session, finalize_voting_session, get_voting_results, master_reset_all, get_roles, add_role, edit_role, remove_role, edit_employee, reorder_rules, retire_employee, reactivate_employee, delete_employee, set_point_decay, get_point_decay, deduct_points_daily, get_latest_voting_results, add_feedback, get_unread_feedback_count, get_feedback, mark_feedback_read, delete_feedback, get_settings, set_settings
 from config import Config
-from forms import VoteForm, AdminLoginForm, StartVotingForm, AddEmployeeForm, AdjustPointsForm, AddRuleForm, EditRuleForm, RemoveRuleForm, EditEmployeeForm, RetireEmployeeForm, ReactivateEmployeeForm, DeleteEmployeeForm, UpdatePotForm, UpdatePriorYearSalesForm, SetPointDecayForm, UpdateAdminForm, AddRoleForm, EditRoleForm, RemoveRoleForm, MasterResetForm, FeedbackForm, LogoutForm, PauseVotingForm, CloseVotingForm, ResetScoresForm, VotingThresholdsForm, VoteLimitsForm, QuickAdjustForm
+from forms import VoteForm, AdminLoginForm, StartVotingForm, AddEmployeeForm, AdjustPointsForm, AddRuleForm, EditRuleForm, RemoveRuleForm, EditEmployeeForm, RetireEmployeeForm, ReactivateEmployeeForm, DeleteEmployeeForm, UpdatePotForm, UpdatePriorYearSalesForm, SetPointDecayForm, UpdateAdminForm, AddRoleForm, EditRoleForm, RemoveRoleForm, MasterResetForm, FeedbackForm, LogoutForm, PauseVotingForm, ResumeVotingForm, CloseVotingForm, FinalizeVotingForm, ResetScoresForm, VotingThresholdsForm, VoteLimitsForm, QuickAdjustForm
 import logging
 import time
 import traceback
@@ -360,6 +360,56 @@ def pause_voting():
         logging.error(f"Error in pause_voting: {str(e)}\n{traceback.format_exc()}")
         return jsonify({'success': False, 'message': 'Server error'}), 500
 
+@app.route("/resume_voting", methods=["POST"])
+def resume_voting():
+    if "admin_id" not in session:
+        flash("Admin login required", "danger")
+        return redirect(url_for('admin'))
+    form = ResumeVotingForm(request.form)
+    if not form.validate_on_submit():
+        logging.error("Resume voting form validation failed: %s", form.errors)
+        return jsonify({'success': False, 'message': 'Invalid form data: ' + str(form.errors)}), 400
+    try:
+        with DatabaseConnection() as conn:
+            success, message = resume_voting_session(conn, session["admin_id"])
+            return jsonify({'success': success, 'message': message})
+    except Exception as e:
+        logging.error(f"Error in resume_voting: {str(e)}\n{traceback.format_exc()}")
+        return jsonify({'success': False, 'message': 'Server error'}), 500
+
+@app.route("/finalize_voting", methods=["POST"])
+def finalize_voting():
+    if "admin_id" not in session:
+        flash("Admin login required", "danger")
+        return redirect(url_for('admin'))
+    form = FinalizeVotingForm(request.form)
+    if not form.validate_on_submit():
+        logging.error("Finalize voting form validation failed: %s", form.errors)
+        return jsonify({'success': False, 'message': 'Invalid form data: ' + str(form.errors)}), 400
+    try:
+        password = form.password.data
+        with DatabaseConnection() as conn:
+            admin = conn.execute("SELECT * FROM admins WHERE admin_id = ?", (session["admin_id"],)).fetchone()
+            if not admin or not check_password_hash(admin["password"], password):
+                logging.error("Invalid admin password for finalize voting: admin_id=%s", session["admin_id"])
+                flash("Invalid admin password", "danger")
+                return jsonify({'success': False, 'message': 'Invalid admin password'}), 403
+            success, message = finalize_voting_session(conn, session["admin_id"])
+            if not success:
+                logging.error("Finalize voting failed: %s", message)
+                flash(message, "danger")
+                return jsonify({'success': False, 'message': message}), 400
+            conn.commit()
+            global _data_cache, _cache_timestamp
+            _data_cache = None
+            _cache_timestamp = None
+            logging.debug("Voting session finalized by admin_id: %s", session["admin_id"])
+            flash("Voting session finalized", "success")
+            return jsonify({'success': True, 'message': message})
+    except Exception as e:
+        logging.error(f"Error in finalize_voting: {str(e)}\n{traceback.format_exc()}")
+        return jsonify({'success': False, 'message': 'Server error'}), 500
+
 @app.route("/vote", methods=["POST"])
 def vote():
     global _data_cache, _cache_timestamp
@@ -563,10 +613,19 @@ def admin():
             decay_role_options = [(role["role_name"], f"{role['role_name']} (Current: {decay.get(role['role_name'], {'points': 1, 'days': []})['points']} points, {', '.join(decay.get(role['role_name'], {'days': []})['days'])})") for role in roles]
             reason_options = [(r["description"], r["description"]) for r in rules] + [("Other", "Other")]
             voting_active = is_voting_active(conn)
+            paused_session_exists = conn.execute(
+                """
+                SELECT 1 FROM voting_sessions vs
+                LEFT JOIN voting_results vr ON vs.session_id = vr.session_id
+                WHERE vr.session_id IS NULL AND vs.end_time IS NOT NULL
+                """
+            ).fetchone() is not None
             # Instantiate and populate forms with attributes for macro compatibility
             start_voting_form = StartVotingForm()
             pause_voting_form = PauseVotingForm()
+            resume_voting_form = ResumeVotingForm()
             close_voting_form = CloseVotingForm()
+            finalize_voting_form = FinalizeVotingForm()
             add_employee_form = AddEmployeeForm()
             add_employee_form.name.data = ''
             add_employee_form.initials.data = ''
@@ -576,6 +635,7 @@ def admin():
             edit_employee_form.name.data = ''
             edit_employee_form.role.data = 'Driver'
             close_voting_form.password.data = ''
+            finalize_voting_form.password.data = ''
             update_pot_form = UpdatePotForm()
             update_pot_form.sales_dollars.data = pot_info.get('sales_dollars', 100000)
             update_pot_form.bonus_percent.data = pot_info.get('bonus_percent', 10)
@@ -658,14 +718,20 @@ def admin():
             reason_options=reason_options,
             history=history,
             voting_active=voting_active,
+            paused_session_exists=paused_session_exists,
             start_voting_form={
                 'username': {'name': 'username', 'id': 'start_voting_username', 'label_text': 'Username', 'value': start_voting_form.username.data, 'class': 'form-control', 'required': True},
                 'password': {'name': 'password', 'id': 'start_voting_password', 'label_text': 'Password', 'value': start_voting_form.password.data, 'class': 'form-control', 'type': 'password', 'required': True}
             },
             pause_voting_form={'submit': {'text': 'Pause Voting', 'class': 'btn btn-warning'}},
+            resume_voting_form={'submit': {'text': 'Resume Voting', 'class': 'btn btn-success'}},
             close_voting_form={
                 'password': {'name': 'password', 'id': 'close_voting_password', 'label_text': 'Admin Password', 'value': close_voting_form.password.data, 'class': 'form-control', 'type': 'password', 'required': True},
                 'submit': {'text': 'Close Voting', 'class': 'btn btn-danger'}
+            },
+            finalize_voting_form={
+                'password': {'name': 'password', 'id': 'finalize_voting_password', 'label_text': 'Admin Password', 'value': finalize_voting_form.password.data, 'class': 'form-control', 'type': 'password', 'required': True},
+                'submit': {'text': 'Finalize Voting', 'class': 'btn btn-danger'}
             },
             add_employee_form={
                 'name': {'name': 'name', 'id': 'add_employee_name', 'label_text': 'Name', 'value': add_employee_form.name.data, 'class': 'form-control', 'required': True},

--- a/forms.py
+++ b/forms.py
@@ -1,6 +1,6 @@
 # forms.py
-# Version: 1.2.21
-# Note: Added VoteLimitsForm to allow configuring maximum vote counts via settings. Compatible with app.py (1.2.111), incentive_service.py (1.2.29), settings.html (1.2.8), incentive.html (1.2.48), script.js (1.2.89), init_db.py (1.2.5).
+# Version: 1.2.22
+# Note: Added ResumeVotingForm and FinalizeVotingForm to manage paused sessions. Compatible with app.py (1.2.113), incentive_service.py (1.2.30), settings.html (1.2.8), incentive.html (1.2.48), script.js (1.2.92), init_db.py (1.2.5).
 
 from flask_wtf import FlaskForm
 from wtforms import StringField, PasswordField, IntegerField, SelectField, SubmitField, TextAreaField, SelectMultipleField, FloatField
@@ -22,9 +22,16 @@ class StartVotingForm(FlaskForm):
 class PauseVotingForm(FlaskForm):
     submit = SubmitField('Pause Voting')
 
+class ResumeVotingForm(FlaskForm):
+    submit = SubmitField('Resume Voting')
+
 class CloseVotingForm(FlaskForm):
     password = PasswordField('Admin Password', validators=[DataRequired()])
     submit = SubmitField('Close Voting')
+
+class FinalizeVotingForm(FlaskForm):
+    password = PasswordField('Admin Password', validators=[DataRequired()])
+    submit = SubmitField('Finalize Voting')
 
 class ResetScoresForm(FlaskForm):
     submit = SubmitField('Reset All Scores')

--- a/static/script.js
+++ b/static/script.js
@@ -1,6 +1,6 @@
 // script.js
-// Version: 1.2.91
-// Note: Bound scoreboard adjust buttons for quick point edits.
+// Version: 1.2.92
+// Note: Added resume and finalize voting handlers.
 
 // Verify Bootstrap Availability
 if (typeof bootstrap === 'undefined') {
@@ -851,6 +851,72 @@ document.addEventListener('DOMContentLoaded', function () {
                 .catch(error => {
                     console.error('Error closing voting:', error);
                     alert('Failed to close voting. Please try again.');
+                });
+            }
+        });
+    }
+
+    const resumeVotingForm = document.getElementById('resumeVotingForm') || document.getElementById('resumeVotingFormUnique');
+    if (resumeVotingForm) {
+        resumeVotingForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            console.log('Resume Voting Form Submitted');
+            if (confirm('Resume the current voting session?')) {
+                fetch('/resume_voting', {
+                    method: 'POST',
+                    body: new FormData(resumeVotingForm)
+                })
+                .then(handleResponse)
+                .then(data => {
+                    if (data) {
+                        console.log('Resume Voting Response:', data);
+                        alert(data.message);
+                        if (data.success) window.location.reload();
+                    }
+                })
+                .catch(error => console.error('Error resuming voting:', error));
+            }
+        });
+    }
+
+    const finalizeVotingForm = document.getElementById('finalizeVotingForm') || document.getElementById('finalizeVotingFormUnique');
+    if (finalizeVotingForm) {
+        finalizeVotingForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            console.log('Finalize Voting Form Submitted');
+            const passwordInput = this.querySelector('#finalize_voting_password');
+            const csrfToken = this.querySelector('input[name="csrf_token"]');
+            if (!passwordInput || !passwordInput.value.trim()) {
+                console.error('Finalize Voting Form Error: Password Missing');
+                alert('Admin password is required.');
+                return;
+            }
+            if (!csrfToken || !csrfToken.value.trim()) {
+                console.error('Finalize Voting Form Error: CSRF Token Missing');
+                alert('Error: CSRF token missing. Please refresh and try again.');
+                return;
+            }
+            if (confirm('Finalize the paused voting session and process votes?')) {
+                const formData = new FormData(this);
+                console.log('Finalize Voting Form Data:', {
+                    password: '****',
+                    csrf_token: formData.get('csrf_token')
+                });
+                fetch('/finalize_voting', {
+                    method: 'POST',
+                    body: formData
+                })
+                .then(handleResponse)
+                .then(data => {
+                    if (data) {
+                        console.log('Finalize Voting Response:', data);
+                        alert(data.message);
+                        if (data.success) window.location.reload();
+                    }
+                })
+                .catch(error => {
+                    console.error('Error finalizing voting:', error);
+                    alert('Failed to finalize voting. Please try again.');
                 });
             }
         });

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -1,8 +1,8 @@
 {% extends "base.html" %}
 {% import "macros.html" as macros %}
 {# admin_manage.html #}
-{# Version: 1.2.45 #}
-{# Note: Enabled rule hover text editing, improved rule layout, fixed settings link, and updated point decay and export options. Compatible with app.py (1.2.112), forms.py (1.2.20), config.py (1.2.6), incentive.html (1.2.45), quick_adjust.html (1.2.18), script.js (1.2.90), style.css (1.2.31), base.html (1.2.21), macros.html (1.2.14), start_voting.html (1.2.7), settings.html (1.2.7), admin_login.html (1.2.6), incentive_service.py (1.2.28), history.html (1.2.6), error.html, init_db.py (1.2.4). #}
+{# Version: 1.2.46 #}
+{# Note: Added resume and finalize voting controls. Compatible with app.py (1.2.113), forms.py (1.2.22), config.py (1.2.6), incentive.html (1.2.48), quick_adjust.html (1.2.18), script.js (1.2.92), style.css (1.2.31), base.html (1.2.21), macros.html (1.2.14), start_voting.html (1.2.7), settings.html (1.2.7), admin_login.html (1.2.6), incentive_service.py (1.2.30), history.html (1.2.6), error.html, init_db.py (1.2.4). #}
 
 {% block content %}
     {% with messages = get_flashed_messages(with_categories=true) %}
@@ -78,15 +78,8 @@
 
         <div class="voting-controls-container">
             <h2>Voting Controls</h2>
-            {% if not voting_active %}
-                <form id="startVotingForm" action="{{ url_for('start_voting') }}" method="POST">
-                    {{ macros.render_csrf_token(id='start_voting_csrf_token') }}
-                    {{ macros.render_field(start_voting_form.username, id='start_voting_username', label_text='Username', class='form-control', required=True, value=start_voting_form.username.data if start_voting_form.username.data else '') }}
-                    {{ macros.render_field(start_voting_form.password, id='start_voting_password', label_text='Password', class='form-control', type='password', required=True, value=start_voting_form.password.data if start_voting_form.password.data else '') }}
-                    {{ macros.render_submit_button('Start Voting', id='startVotingBtn', class='btn btn-primary') }}
-                </form>
-            {% else %}
-                <form action="{{ url_for('pause_voting') }}" method="POST">
+            {% if voting_active %}
+                <form id="pauseVotingForm" action="{{ url_for('pause_voting') }}" method="POST">
                     {{ macros.render_csrf_token(id='pause_voting_csrf_token') }}
                     {{ macros.render_submit_button('Pause Voting', class='btn btn-warning') }}
                 </form>
@@ -94,6 +87,23 @@
                     {{ macros.render_csrf_token(id='close_voting_csrf_token') }}
                     {{ macros.render_field(close_voting_form.password, id='close_voting_password', label_text='Admin Password', class='form-control', type='password', required=True, value=close_voting_form.password.data if close_voting_form.password.data else '') }}
                     {{ macros.render_submit_button('Close Voting', class='btn btn-danger') }}
+                </form>
+            {% elif paused_session_exists %}
+                <form id="resumeVotingForm" action="{{ url_for('resume_voting') }}" method="POST">
+                    {{ macros.render_csrf_token(id='resume_voting_csrf_token') }}
+                    {{ macros.render_submit_button('Resume Voting', class='btn btn-success') }}
+                </form>
+                <form id="finalizeVotingForm" action="{{ url_for('finalize_voting') }}" method="POST">
+                    {{ macros.render_csrf_token(id='finalize_voting_csrf_token') }}
+                    {{ macros.render_field(finalize_voting_form.password, id='finalize_voting_password', label_text='Admin Password', class='form-control', type='password', required=True, value=finalize_voting_form.password.data if finalize_voting_form.password.data else '') }}
+                    {{ macros.render_submit_button('Finalize Voting', class='btn btn-danger') }}
+                </form>
+            {% else %}
+                <form id="startVotingForm" action="{{ url_for('start_voting') }}" method="POST">
+                    {{ macros.render_csrf_token(id='start_voting_csrf_token') }}
+                    {{ macros.render_field(start_voting_form.username, id='start_voting_username', label_text='Username', class='form-control', required=True, value=start_voting_form.username.data if start_voting_form.username.data else '') }}
+                    {{ macros.render_field(start_voting_form.password, id='start_voting_password', label_text='Password', class='form-control', type='password', required=True, value=start_voting_form.password.data if start_voting_form.password.data else '') }}
+                    {{ macros.render_submit_button('Start Voting', id='startVotingBtn', class='btn btn-primary') }}
                 </form>
             {% endif %}
         </div>


### PR DESCRIPTION
## Summary
- Allow admins to resume paused voting sessions
- Add finalize action to process results for sessions left in a paused state
- Wire up UI and JS handlers for resume/finalize buttons

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689ddb7c72708325b1ba714d12c13a87