### PR TITLE
Add resume and finalize voting controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,7 +202,7 @@ Points Rules: Admins can define rules for common adjustments. Used in both votin
 
 Manage Employees: Add, update, retire, reactivate, or fully delete employee records.
 
-Voting Controls: Open, pause, close, or end voting sessions for a week.
+Voting Controls: Open, pause, resume, finalize, or end voting sessions for a week.
 
 Payout Settings: Edit pot sales, bonus percent, role shares.
 
@@ -275,7 +275,7 @@ Voting session management:
 
 Open new session (start_voting.html)
 
-Pause or end session from admin panel.
+Pause, resume, finalize or end session from admin panel.
 
 Audit logging:
 

--- a/static/script.js
+++ b/static/script.js
@@ -954,6 +954,29 @@ document.addEventListener('DOMContentLoaded', function () {
         });
     }
 
+    const resumeVotingForm = document.getElementById('resumeVotingForm');
+    if (resumeVotingForm) {
+        resumeVotingForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            console.log('Resume Voting Form Submitted');
+            if (confirm('Resume the paused voting session?')) {
+                fetch('/resume_voting', {
+                    method: 'POST',
+                    body: new FormData(resumeVotingForm)
+                })
+                .then(handleResponse)
+                .then(data => {
+                    if (data) {
+                        console.log('Resume Voting Response:', data);
+                        alert(data.message);
+                        if (data.success) window.location.reload();
+                    }
+                })
+                .catch(error => console.error('Error resuming voting:', error));
+            }
+        });
+    }
+
     const closeVotingForm = document.getElementById('closeVotingForm') || document.getElementById('closeVotingFormUnique');
     if (closeVotingForm) {
         closeVotingForm.addEventListener('submit', function (e) {
@@ -993,6 +1016,46 @@ document.addEventListener('DOMContentLoaded', function () {
                     console.error('Error closing voting:', error);
                     alert('Failed to close voting. Please try again.');
                 });
+            }
+        });
+    }
+
+    const finalizeVotingForm = document.getElementById('finalizeVotingForm');
+    if (finalizeVotingForm) {
+        finalizeVotingForm.addEventListener('submit', function (e) {
+            e.preventDefault();
+            console.log('Finalize Voting Form Submitted');
+            const passwordInput = this.querySelector('#finalize_voting_password');
+            const csrfToken = this.querySelector('input[name="csrf_token"]');
+            if (!passwordInput || !passwordInput.value.trim()) {
+                console.error('Finalize Voting Form Error: Password Missing');
+                alert('Admin password is required.');
+                return;
+            }
+            if (!csrfToken || !csrfToken.value.trim()) {
+                console.error('Finalize Voting Form Error: CSRF Token Missing');
+                alert('Error: CSRF token missing. Please refresh and try again.');
+                return;
+            }
+            if (confirm('Finalize the paused voting session and process votes?')) {
+                const formData = new FormData(this);
+                console.log('Finalize Voting Form Data:', {
+                    password: '****',
+                    csrf_token: formData.get('csrf_token')
+                });
+                fetch('/finalize_voting', {
+                    method: 'POST',
+                    body: formData
+                })
+                .then(handleResponse)
+                .then(data => {
+                    if (data) {
+                        console.log('Finalize Voting Response:', data);
+                        alert(data.message);
+                        if (data.success) { rainCoins(); window.location.reload(); }
+                    }
+                })
+                .catch(error => console.error('Error finalizing voting:', error));
             }
         });
     }

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -79,14 +79,7 @@
 
         <div class="voting-controls-container">
             <h2>Voting Controls</h2>
-            {% if not voting_active %}
-                <form id="startVotingForm" action="{{ url_for('start_voting') }}" method="POST">
-                    {{ macros.render_csrf_token(id='start_voting_csrf_token') }}
-                    {{ macros.render_field(start_voting_form.username, id='start_voting_username', label_text='Username', class='form-control', required=True, value=start_voting_form.username.data if start_voting_form.username.data else '') }}
-                    {{ macros.render_field(start_voting_form.password, id='start_voting_password', label_text='Password', class='form-control', type='password', required=True, value=start_voting_form.password.data if start_voting_form.password.data else '') }}
-                    {{ macros.render_submit_button('Start Voting', id='startVotingBtn', class='btn btn-primary') }}
-                </form>
-            {% else %}
+            {% if voting_active %}
                 <form id="pauseVotingForm" action="{{ url_for('pause_voting') }}" method="POST">
                     {{ macros.render_csrf_token(id='pause_voting_csrf_token') }}
                     {{ macros.render_submit_button('Pause Voting', class='btn btn-warning') }}
@@ -95,6 +88,23 @@
                     {{ macros.render_csrf_token(id='close_voting_csrf_token') }}
                     {{ macros.render_field(close_voting_form.password, id='close_voting_password', label_text='Admin Password', class='form-control', type='password', required=True, value=close_voting_form.password.data if close_voting_form.password.data else '') }}
                     {{ macros.render_submit_button('Close Voting', class='btn btn-danger') }}
+                </form>
+            {% elif voting_paused %}
+                <form id="resumeVotingForm" action="{{ url_for('resume_voting') }}" method="POST">
+                    {{ macros.render_csrf_token(id='resume_voting_csrf_token') }}
+                    {{ macros.render_submit_button('Resume Voting', class='btn btn-success') }}
+                </form>
+                <form id="finalizeVotingForm" action="{{ url_for('finalize_voting') }}" method="POST">
+                    {{ macros.render_csrf_token(id='finalize_voting_csrf_token') }}
+                    {{ macros.render_field(finalize_voting_form.password, id='finalize_voting_password', label_text='Admin Password', class='form-control', type='password', required=True, value=finalize_voting_form.password.data if finalize_voting_form.password.data else '') }}
+                    {{ macros.render_submit_button('Finalize Voting', class='btn btn-danger') }}
+                </form>
+            {% else %}
+                <form id="startVotingForm" action="{{ url_for('start_voting') }}" method="POST">
+                    {{ macros.render_csrf_token(id='start_voting_csrf_token') }}
+                    {{ macros.render_field(start_voting_form.username, id='start_voting_username', label_text='Username', class='form-control', required=True, value=start_voting_form.username.data if start_voting_form.username.data else '') }}
+                    {{ macros.render_field(start_voting_form.password, id='start_voting_password', label_text='Password', class='form-control', type='password', required=True, value=start_voting_form.password.data if start_voting_form.password.data else '') }}
+                    {{ macros.render_submit_button('Start Voting', id='startVotingBtn', class='btn btn-primary') }}
                 </form>
             {% endif %}
         </div>


### PR DESCRIPTION
## Summary
- Allow admins to resume paused voting sessions.
- Provide option to finalize paused sessions and compute results.
- Document new voting controls in README.

## Testing
- `python -m py_compile app.py incentive_service.py`


------
https://chatgpt.com/codex/tasks/task_e_689ddf641b3c8325bf8ca2d1485d3c17