### PR TITLE
Add mini-game infrastructure and PIN support

### DIFF
--- a/forms.py
+++ b/forms.py
@@ -37,6 +37,7 @@ class AddEmployeeForm(FlaskForm):
     name = StringField('Name', validators=[DataRequired(), Length(min=1, max=100)])
     initials = StringField('Initials', validators=[DataRequired(), Length(min=2, max=10)])
     role = SelectField('Role', validators=[DataRequired()], choices=[])
+    pin = PasswordField('PIN (4-6 digits)', validators=[DataRequired(), Length(min=4, max=6)])
     submit = SubmitField('Add Employee')
 
 class AdjustPointsForm(FlaskForm):
@@ -67,6 +68,7 @@ class EditEmployeeForm(FlaskForm):
     employee_id = SelectField('Employee', validators=[DataRequired()], choices=[])
     name = StringField('New Name', validators=[DataRequired(), Length(min=1, max=100)])
     role = SelectField('New Role', validators=[DataRequired()], choices=[])
+    pin = PasswordField('PIN (4-6 digits)', validators=[DataRequired(), Length(min=4, max=6)])
     submit = SubmitField('Edit Employee')
 
 class RetireEmployeeForm(FlaskForm):
@@ -172,3 +174,44 @@ class QuickAdjustForm(FlaskForm):
     username = StringField('Username', validators=[Optional(), Length(min=1, max=50)])
     password = PasswordField('Password', validators=[Optional()])
     submit = SubmitField('Adjust Points')
+
+
+class AwardGameForm(FlaskForm):
+    employee_id = SelectField('Employee', validators=[DataRequired()], choices=[])
+    game_type = SelectField('Game Type', validators=[DataRequired()], choices=[('slot', 'Slot'), ('scratch', 'Scratch-Off'), ('roulette', 'Roulette')])
+    submit = SubmitField('Award Game')
+
+
+class PlayGameForm(FlaskForm):
+    pin = PasswordField('Enter PIN', validators=[DataRequired(), Length(min=4, max=6)])
+    game_id = StringField('Game ID', validators=[DataRequired()])
+    submit = SubmitField('Play')
+
+
+class MiniGameSettingsForm(FlaskForm):
+    award_chance_points = IntegerField('Award % on Points', validators=[DataRequired(), NumberRange(min=0, max=100)])
+    award_chance_vote = IntegerField('Award % on Vote', validators=[DataRequired(), NumberRange(min=0, max=100)])
+    points_amount = IntegerField('Points Prize Amount', validators=[DataRequired()])
+    points_chance = IntegerField('Points Prize Chance', validators=[DataRequired(), NumberRange(min=0, max=100)])
+    prize1_desc = StringField('Prize 1 Description', validators=[Optional(), Length(max=100)])
+    prize1_value = FloatField('Prize 1 Value', validators=[Optional()])
+    prize1_chance = IntegerField('Prize 1 Chance', validators=[Optional(), NumberRange(min=0, max=100)])
+    prize2_desc = StringField('Prize 2 Description', validators=[Optional(), Length(max=100)])
+    prize2_value = FloatField('Prize 2 Value', validators=[Optional()])
+    prize2_chance = IntegerField('Prize 2 Chance', validators=[Optional(), NumberRange(min=0, max=100)])
+    prize3_desc = StringField('Prize 3 Description', validators=[Optional(), Length(max=100)])
+    prize3_value = FloatField('Prize 3 Value', validators=[Optional()])
+    prize3_chance = IntegerField('Prize 3 Chance', validators=[Optional(), NumberRange(min=0, max=100)])
+    submit = SubmitField('Save Mini-Game Settings')
+
+
+class EmployeeLoginForm(FlaskForm):
+    employee_id = IntegerField('Employee ID', validators=[DataRequired()])
+    pin = PasswordField('PIN', validators=[DataRequired(), Length(min=4, max=6)])
+    submit = SubmitField('Access')
+
+
+class ChangePinForm(FlaskForm):
+    current_pin = PasswordField('Current PIN', validators=[DataRequired(), Length(min=4, max=6)])
+    new_pin = PasswordField('New PIN', validators=[DataRequired(), Length(min=4, max=6)])
+    submit = SubmitField('Change PIN')

--- a/incentive_service.py
+++ b/incentive_service.py
@@ -10,6 +10,8 @@ from logging_config import setup_logging
 import json
 import time
 import traceback
+import random
+from werkzeug.security import generate_password_hash, check_password_hash
 
 _pot_cache = None
 _pot_cache_timestamp = None
@@ -439,27 +441,36 @@ def cast_votes(conn, voter_initials, votes):
                 )
         duration = time.time() - start_time
         logging.debug(f"Vote processing completed in {duration:.2f} seconds for {voter_initials}")
+        settings = get_settings(conn)
+        try:
+            cfg = json.loads(settings.get('mini_game_settings', '{}'))
+            chance = int(cfg.get('award_chance_vote', 0))
+        except (ValueError, json.JSONDecodeError):
+            chance = 0
+        if random.randint(1, 100) <= chance:
+            award_mini_game(conn, voter_id)
         return True, "JACKPOT VOTE CAST! MONEY INCOMING!"
     except sqlite3.OperationalError as e:
         duration = time.time() - start_time
         logging.error(f"Database error during voting for {voter_initials}: {str(e)}, duration={duration:.2f} seconds")
         return False, "Failed to record votes due to database error"
 
-def add_employee(conn, name, initials, role):
+def add_employee(conn, name, initials, role, pin=None):
     role_lower = role.lower()
     valid_role = conn.execute("SELECT 1 FROM roles WHERE LOWER(role_name) = ?", (role_lower,)).fetchone()
     if not valid_role:
         return False, f"Role '{role}' does not exist"
-    
+
     try:
+        pin_hash = generate_password_hash(pin) if pin else None
         # Get the highest existing employee_id and increment it
         max_id_row = conn.execute("SELECT MAX(CAST(SUBSTR(employee_id, 2) AS INTEGER)) as max_id FROM employees").fetchone()
         max_id = max_id_row["max_id"] if max_id_row["max_id"] is not None else 0
         employee_id = f"E{str(max_id + 1).zfill(3)}"
-        
+
         conn.execute(
-            "INSERT INTO employees (employee_id, name, initials, score, role, active) VALUES (?, ?, ?, 50, ?, 1)",
-            (employee_id, name, initials, role_lower)
+            "INSERT INTO employees (employee_id, name, initials, score, role, active, pin_hash) VALUES (?, ?, ?, 50, ?, 1, ?)",
+            (employee_id, name, initials, role_lower, pin_hash)
         )
         return True, f"Employee {name} added with ID {employee_id}"
     except sqlite3.IntegrityError as e:
@@ -489,18 +500,74 @@ def delete_employee(conn, employee_id):
     affected = conn.total_changes
     return affected > 0, f"Employee {employee_id} permanently deleted" if affected > 0 else "Employee not found"
 
-def edit_employee(conn, employee_id, name, role):
+def edit_employee(conn, employee_id, name, role, pin=None):
     role_lower = role.lower()
     valid_role = conn.execute("SELECT 1 FROM roles WHERE LOWER(role_name) = ?", (role_lower,)).fetchone()
     if not valid_role:
         return False, f"Role '{role}' does not exist"
-    
-    conn.execute(
-        "UPDATE employees SET name = ?, role = ? WHERE employee_id = ?",
-        (name, role_lower, employee_id)
-    )
+
+    if pin:
+        pin_hash = generate_password_hash(pin)
+        conn.execute(
+            "UPDATE employees SET name = ?, role = ?, pin_hash = ? WHERE employee_id = ?",
+            (name, role_lower, pin_hash, employee_id)
+        )
+    else:
+        conn.execute(
+            "UPDATE employees SET name = ?, role = ? WHERE employee_id = ?",
+            (name, role_lower, employee_id)
+        )
     affected = conn.total_changes
     return affected > 0, f"Employee {employee_id} updated" if affected > 0 else "Employee not found"
+
+
+def verify_pin(conn, employee_id, pin):
+    row = conn.execute("SELECT pin_hash FROM employees WHERE employee_id = ?", (employee_id,)).fetchone()
+    if not row or not row["pin_hash"]:
+        return False
+    return check_password_hash(row["pin_hash"], pin)
+
+
+def award_mini_game(conn, employee_id, game_type=None):
+    settings = get_settings(conn)
+    try:
+        cfg = json.loads(settings.get("mini_game_settings", "{}"))
+    except json.JSONDecodeError:
+        cfg = {}
+    if not game_type:
+        game_types = cfg.get("game_types", ["slot", "scratch", "roulette"])
+        game_type = random.choice(game_types)
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    conn.execute(
+        "INSERT INTO mini_games (employee_id, game_type, awarded_date, status) VALUES (?, ?, ?, 'unused')",
+        (employee_id, game_type, now),
+    )
+    return True, game_type
+
+
+def get_employee_games(conn, employee_id):
+    return conn.execute(
+        "SELECT * FROM mini_games WHERE employee_id = ? AND status = 'unused'",
+        (employee_id,),
+    ).fetchall()
+
+
+def play_mini_game(conn, game_id, outcome_json):
+    now = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    conn.execute(
+        "UPDATE mini_games SET status='played', played_date=?, outcome=? WHERE id=?",
+        (now, outcome_json, game_id),
+    )
+    data = json.loads(outcome_json) if outcome_json else {}
+    conn.execute(
+        "INSERT INTO game_history (mini_game_id, play_date, prize_type, prize_amount) VALUES (?, ?, ?, ?)",
+        (game_id, now, data.get('prize'), data.get('amount')),
+    )
+    if data.get('prize') == 'points':
+        emp_row = conn.execute("SELECT employee_id FROM mini_games WHERE id = ?", (game_id,)).fetchone()
+        if emp_row:
+            adjust_points(conn, emp_row["employee_id"], data.get('amount', 0), 'system', 'Mini-game win')
+    return True
 
 def adjust_points(conn, employee_id, points, admin_id, reason, notes=""):
     now = datetime.now()
@@ -528,6 +595,16 @@ def adjust_points(conn, employee_id, points, admin_id, reason, notes=""):
         else:
             logging.error(f"Database error in adjust_points: {str(e)}\n{traceback.format_exc()}")
             raise
+
+    if points > 0:
+        settings = get_settings(conn)
+        try:
+            cfg = json.loads(settings.get('mini_game_settings', '{}'))
+            chance = int(cfg.get('award_chance_points', 0))
+        except (ValueError, json.JSONDecodeError):
+            chance = 0
+        if random.randint(1, 100) <= chance:
+            award_mini_game(conn, employee_id)
     return True, f"Adjusted {points} points for employee {employee_id}"
 
 def reset_scores(conn, admin_id, reason=None):

--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -260,6 +260,7 @@
                 {{ macros.render_field(add_employee_form.name, id='add_employee_name', label_text='Name', class='form-control', required=True, value=add_employee_form.name.data if add_employee_form.name.data else 'Enter name') }}
                 {{ macros.render_field(add_employee_form.initials, id='add_employee_initials', label_text='Initials', class='form-control', required=True, value=add_employee_form.initials.data if add_employee_form.initials.data else 'Enter initials') }}
                 {{ macros.render_select_field(add_employee_form.role, id='add_employee_role', label_text='Role', options=role_options, selected_value=add_employee_form.role.data if add_employee_form.role.data else 'Driver') }}
+                {{ macros.render_field(add_employee_form.pin, id='add_employee_pin', label_text='PIN', class='form-control', type='password', required=True, value='') }}
                 {{ macros.render_submit_button('Add Employee', class='btn btn-primary') }}
             </form>
         </div>
@@ -271,11 +272,50 @@
                 {{ macros.render_select_field(edit_employee_form.employee_id, id='edit_employee_id', label_text='Employee', options=employee_options, selected_value=edit_employee_form.employee_id.data if edit_employee_form.employee_id.data else employee_options[0][0] if employee_options else '') }}
                 {{ macros.render_field(edit_employee_form.name, id='edit_employee_name', label_text='Name', class='form-control', required=True, value=edit_employee_form.name.data if edit_employee_form.name.data else 'Enter name') }}
                 {{ macros.render_select_field(edit_employee_form.role, id='edit_employee_role', label_text='Role', options=role_options, selected_value=edit_employee_form.role.data if edit_employee_form.role.data else 'Driver') }}
+                {{ macros.render_field(edit_employee_form.pin, id='edit_employee_pin', label_text='PIN', class='form-control', type='password', required=True, value='') }}
                 {{ macros.render_submit_button('Update Employee', class='btn btn-primary') }}
                 <button type="button" id="retireBtn" class="btn btn-warning">Retire</button>
                 <button type="button" id="reactivateBtn" class="btn btn-success">Reactivate</button>
                 <button type="button" id="deleteBtn" class="btn btn-danger">Delete</button>
             </form>
+        </div>
+
+        <div class="award-game-container">
+            <h2>Award Mini-Game</h2>
+            <form id="awardGameForm" action="{{ url_for('admin_award_game') }}" method="POST" class="mb-4">
+                {{ macros.render_csrf_token(id='award_game_csrf_token') }}
+                {{ macros.render_select_field(award_game_form.employee_id, id='award_game_employee', label_text='Employee', options=employee_options, selected_value=award_game_form.employee_id.selected_value if award_game_form.employee_id.selected_value else employee_options[0][0] if employee_options else '') }}
+                {{ macros.render_select_field(award_game_form.game_type, id='award_game_type', label_text='Game Type', options=[('slot','Slot'),('scratch','Scratch-Off'),('roulette','Roulette')], selected_value=award_game_form.game_type.selected_value if award_game_form.game_type.selected_value else 'slot') }}
+                {{ macros.render_submit_button('Award Game', class='btn btn-primary') }}
+            </form>
+        </div>
+
+        <div class="mini-game-overview-container">
+            <h2>Mini-Game Overview</h2>
+            <table class="table table-striped">
+                <thead>
+                    <tr>
+                        <th>ID</th>
+                        <th>Employee</th>
+                        <th>Game Type</th>
+                        <th>Status</th>
+                        <th>Outcome</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    {% for g in mini_games %}
+                        <tr>
+                            <td>{{ g.id }}</td>
+                            <td>{{ g.name }}</td>
+                            <td>{{ g.game_type }}</td>
+                            <td>{{ g.status }}</td>
+                            <td>{{ g.outcome if g.outcome else 'N/A' }}</td>
+                        </tr>
+                    {% else %}
+                        <tr><td colspan="5">No mini-games awarded</td></tr>
+                    {% endfor %}
+                </tbody>
+            </table>
         </div>
 
         <div class="feedback-container">

--- a/templates/base.html
+++ b/templates/base.html
@@ -58,6 +58,9 @@
                     <li class="nav-item">
                         <a class="nav-link" href="{{ url_for('history') }}">History</a>
                     </li>
+                    <li class="nav-item">
+                        <a class="nav-link" href="{{ url_for('employee_portal') }}">Employee Portal</a>
+                    </li>
                     {% if session.admin_id %}
                         <li class="nav-item">
                             <a class="nav-link" href="{{ url_for('admin') }}">Admin</a>

--- a/templates/employee_portal.html
+++ b/templates/employee_portal.html
@@ -1,0 +1,64 @@
+{% extends "base.html" %}
+{% import "macros.html" as macros %}
+{% block content %}
+<div class="vegas-wrapper">
+    {% with messages = get_flashed_messages(with_categories=true) %}
+        {% if messages %}
+            {% for category, message in messages %}
+                <div class="alert alert-{{ category }} alert-dismissible fade show" role="alert">
+                    {{ message|safe }}
+                    <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+                </div>
+            {% endfor %}
+        {% endif %}
+    {% endwith %}
+
+    {% if not employee %}
+        <h2>Employee Access</h2>
+        <form action="{{ url_for('employee_portal') }}" method="POST" class="mb-4">
+            {{ macros.render_csrf_token() }}
+            {{ macros.render_field(login_form.employee_id, id='employee_id', label_text='Employee ID', class='form-control', type='number', required=True, value='') }}
+            {{ macros.render_field(login_form.pin, id='employee_pin', label_text='PIN', class='form-control', type='password', required=True, value='') }}
+            {{ macros.render_submit_button('Access', class='btn btn-primary') }}
+        </form>
+    {% else %}
+        <h2>Welcome, {{ employee.name }}</h2>
+        <p>Your Points: {{ employee.score }}</p>
+
+        <h3>Unused Mini-Games</h3>
+        <ul>
+            {% for g in unused_games %}
+                <li>{{ g.game_type }} awarded {{ g.awarded_date }}
+                    <form action="{{ url_for('play_game', game_id=g.id) }}" method="POST" style="display:inline;">
+                        {{ macros.render_csrf_token() }}
+                        {{ macros.render_submit_button('Play', class='btn btn-sm btn-success') }}
+                    </form>
+                </li>
+            {% else %}
+                <li>No unused games</li>
+            {% endfor %}
+        </ul>
+
+        <h3>Played Mini-Games</h3>
+        <ul>
+            {% for g in used_games %}
+                <li>{{ g.game_type }} - {{ g.outcome if g.outcome else 'No Prize' }}</li>
+            {% else %}
+                <li>No played games</li>
+            {% endfor %}
+        </ul>
+
+        <h3>Change PIN</h3>
+        <form action="{{ url_for('employee_change_pin') }}" method="POST" class="mb-3">
+            {{ macros.render_csrf_token() }}
+            {{ macros.render_field(change_pin_form.current_pin, id='current_pin', label_text='Current PIN', class='form-control', type='password', required=True, value='') }}
+            {{ macros.render_field(change_pin_form.new_pin, id='new_pin', label_text='New PIN', class='form-control', type='password', required=True, value='') }}
+            {{ macros.render_submit_button('Change PIN', class='btn btn-warning') }}
+        </form>
+        <form action="{{ url_for('employee_logout') }}" method="POST">
+            {{ macros.render_csrf_token() }}
+            {{ macros.render_submit_button('Logout', class='btn btn-secondary') }}
+        </form>
+    {% endif %}
+</div>
+{% endblock %}

--- a/templates/incentive.html
+++ b/templates/incentive.html
@@ -27,6 +27,10 @@
         </div>
     {% endif %}
 
+    <div class="text-center mb-3">
+        <a href="{{ url_for('employee_portal') }}" class="btn btn-info">Employee Portal</a>
+    </div>
+
     <div class="container casino-table">
         <h2 class="text-center">Scoreboard</h2>
         <table class="table table-striped table-hover" id="scoreboardTable">


### PR DESCRIPTION
## Summary
- Provide employee portal with PIN login for viewing points, playing mini-games, and updating PINs
- Allow admins to award mini-games, manage employee PINs, and review all awarded game results
- Expose mini-game access links on main navigation and incentive page

## Testing
- `python -m py_compile init_db.py forms.py incentive_service.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_689f6dd7acb083258ca19b5e85f5380e