### PR TITLE
Allow configuring service port via install and admin settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,10 @@ Decay is set by role and day; deducted points apply daily on specified days for 
 ## start.sh
 #!/bin/bash
 source venv/bin/activate
-gunicorn --workers 4 --timeout 180 --bind 0.0.0.0:6800 app:app
+PORT=$(python get_port.py)
+gunicorn --workers 4 --timeout 180 --bind 0.0.0.0:$PORT app:app
+
+The install script asks for the desired port and saves it to the database. The master account can update this port later from the **Settings** page. After changing the port, use the **Restart Service** button on the Settings page to apply the new port.
 
 
 # init_db.py
@@ -620,7 +623,8 @@ matplotlib==3.9.1
 
 #!/bin/bash
 source venv/bin/activate
-gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:6800 app:app
+PORT=$(python get_port.py)
+gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:$PORT app:app
 
 ## 🚀 Automatic Deployment from GitHub to Raspberry Pi (Self-Hosted Runner)
 
@@ -703,4 +707,5 @@ Q1: How do I deploy from a branch other than main?
 Q2: How do I add post-deploy steps (migrate DB, install requirements, etc)?
 
 Q3: How do I rotate the SSH deploy key if compromised?
+
 

--- a/forms.py
+++ b/forms.py
@@ -166,3 +166,8 @@ class QuickAdjustForm(FlaskForm):
     username = StringField('Username', validators=[Optional(), Length(min=1, max=50)])
     password = PasswordField('Password', validators=[Optional()])
     submit = SubmitField('Adjust Points')
+
+class PortSettingsForm(FlaskForm):
+    server_port = IntegerField('Server Port', validators=[DataRequired(), NumberRange(min=1, max=65535)])
+    submit = SubmitField('Update Port')
+

--- a/get_port.py
+++ b/get_port.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+import sqlite3
+from config import Config
+from incentive_service import get_settings
+
+conn = sqlite3.connect(Config.INCENTIVE_DB_FILE)
+settings = get_settings(conn)
+print(settings.get('server_port', '6800'))
+conn.close()
+

--- a/incentive_service.py
+++ b/incentive_service.py
@@ -979,6 +979,9 @@ def get_settings(conn):
         if 'surface_alt_color' not in settings:
             set_settings(conn, 'surface_alt_color', '#1A1A1A')
             settings['surface_alt_color'] = '#1A1A1A'
+        if 'server_port' not in settings:
+            set_settings(conn, 'server_port', '6800')
+            settings['server_port'] = '6800'
         for section in Config.ADMIN_SECTIONS:
             key = f'allow_section_{section}'
             if key not in settings:

--- a/init_db.py
+++ b/init_db.py
@@ -208,7 +208,8 @@ def initialize_incentive_db():
         ('secondary_color', '#000000'),
         ('background_color', '#3A3A3A'),
         ('surface_color', '#222222'),
-        ('surface_alt_color', '#1A1A1A')
+        ('surface_alt_color', '#1A1A1A'),
+        ('server_port', '6800')
     ]
     default_settings.extend([(f'allow_section_{section}', '0') for section in Config.ADMIN_SECTIONS])
     cursor.executemany("INSERT OR IGNORE INTO settings (key, value) VALUES (?, ?)", default_settings)

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,9 @@
 #!/bin/bash
 echo "Setting up RFID Incentive Program..."
 
+read -p "Enter server port [6800]: " PORT
+PORT=${PORT:-6800}
+
 # Create virtual environment
 python3 -m venv venv
 source venv/bin/activate
@@ -11,9 +14,21 @@ pip install flask gunicorn werkzeug
 # Initialize database
 python init_db.py
 
+# Store selected port in settings
+python - <<PY
+import sqlite3
+from config import Config
+from incentive_service import set_settings
+conn = sqlite3.connect(Config.INCENTIVE_DB_FILE)
+set_settings(conn, 'server_port', '$PORT')
+conn.commit()
+conn.close()
+PY
+
 # Make start script executable
 chmod +x start.sh
 
 echo "Setup complete! To run the server, use './start.sh'"
-echo "To access, visit http://rfid:6800/"
+echo "To access, visit http://rfid:$PORT/"
 echo "Master Admin: username 'master', password 'Master8101'"
+

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,4 @@
 #!/bin/bash
 source venv/bin/activate
-gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:6800 app:app
+PORT=$(python get_port.py)
+gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:$PORT app:app

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -95,7 +95,20 @@
                     {% endfor %}
                 </select>
             </div>
-            {{ macros.render_submit_button('Update Reporting Settings', class='btn btn-primary') }}
+         {{ macros.render_submit_button('Update Reporting Settings', class='btn btn-primary') }}
+        </form>
+
+        <h2>Server Port</h2>
+        <form action="{{ url_for('admin_settings') }}" method="POST" id="portSettingsForm">
+            {{ port_settings_form.csrf_token(id='port_settings_csrf_token') }}
+            {{ macros.render_field(port_settings_form.server_port, id='server_port', label_text='Port', class='form-control', type='number', required=True, value=port_settings_form.server_port.data) }}
+            {{ macros.render_submit_button('Update Port', class='btn btn-primary') }}
+        </form>
+
+        <h2>Service Control</h2>
+        <form action="{{ url_for('admin_restart_service') }}" method="POST" id="restartServiceForm">
+            {{ macros.render_csrf_token(id='restart_service_csrf_token') }}
+            {{ macros.render_submit_button('Restart Service', class='btn btn-warning') }}
         </form>
 
         <h2>Theme Settings</h2>


### PR DESCRIPTION
## Summary
- prompt for server port during installation and store in database
- add master-admin setting to update server port and restart notice
- start service using stored port via helper script
- add master-admin button to restart the service (falls back to reboot)

## Testing
- `python -m py_compile forms.py app.py incentive_service.py init_db.py get_port.py`


------
https://chatgpt.com/codex/tasks/task_e_68a4a47db7f08325b08baaf1eaf38860