### PR TITLE
feat: configurable port and service controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ Decay is set by role and day; deducted points apply daily on specified days for 
 ## start.sh
 #!/bin/bash
 source venv/bin/activate
-gunicorn --workers 4 --timeout 180 --bind 0.0.0.0:6800 app:app
+gunicorn --workers 4 --timeout 180 --bind 0.0.0.0:$PORT app:app
 
 
 # init_db.py
@@ -620,7 +620,7 @@ matplotlib==3.9.1
 
 #!/bin/bash
 source venv/bin/activate
-gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:6800 app:app
+gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:$PORT app:app
 
 ## 🚀 Automatic Deployment from GitHub to Raspberry Pi (Self-Hosted Runner)
 

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from werkzeug.security import check_password_hash, generate_password_hash
 from flask_wtf.csrf import CSRFProtect, CSRFError
 from incentive_service import DatabaseConnection, get_scoreboard, start_voting_session, is_voting_active, cast_votes, add_employee, reset_scores, get_history, adjust_points, get_rules, add_rule, edit_rule, remove_rule, get_pot_info, update_pot_info, close_voting_session, pause_voting_session, resume_voting_session, finalize_voting_session, get_voting_results, master_reset_all, get_roles, add_role, edit_role, remove_role, edit_employee, reorder_rules, retire_employee, reactivate_employee, delete_employee, set_point_decay, get_point_decay, deduct_points_daily, get_latest_voting_results, add_feedback, get_unread_feedback_count, get_feedback, mark_feedback_read, delete_feedback, get_settings, set_settings, get_recent_admin_adjustments, award_mini_game, play_mini_game, verify_pin
 from config import Config
-from forms import VoteForm, AdminLoginForm, StartVotingForm, AddEmployeeForm, AdjustPointsForm, AddRuleForm, EditRuleForm, RemoveRuleForm, EditEmployeeForm, RetireEmployeeForm, ReactivateEmployeeForm, DeleteEmployeeForm, UpdatePotForm, UpdatePriorYearSalesForm, SetPointDecayForm, UpdateAdminForm, AddRoleForm, EditRoleForm, RemoveRoleForm, MasterResetForm, FeedbackForm, LogoutForm, PauseVotingForm, CloseVotingForm, ResetScoresForm, VotingThresholdsForm, VoteLimitsForm, ScoreboardSettingsForm, QuickAdjustForm, AwardGameForm, EmployeeLoginForm, ChangePinForm
+from forms import VoteForm, AdminLoginForm, StartVotingForm, AddEmployeeForm, AdjustPointsForm, AddRuleForm, EditRuleForm, RemoveRuleForm, EditEmployeeForm, RetireEmployeeForm, ReactivateEmployeeForm, DeleteEmployeeForm, UpdatePotForm, UpdatePriorYearSalesForm, SetPointDecayForm, UpdateAdminForm, AddRoleForm, EditRoleForm, RemoveRoleForm, MasterResetForm, FeedbackForm, LogoutForm, PauseVotingForm, CloseVotingForm, ResetScoresForm, VotingThresholdsForm, VoteLimitsForm, ScoreboardSettingsForm, QuickAdjustForm, AwardGameForm, EmployeeLoginForm, ChangePinForm, PortForm, RestartServiceForm, RebootPiForm
 import logging
 from logging_config import setup_logging
 import time
@@ -25,6 +25,7 @@ import matplotlib.pyplot as plt
 import os
 import json
 import random
+import subprocess
 
 # In-memory cache for /data endpoint
 _data_cache = None
@@ -1692,7 +1693,21 @@ def admin_settings():
         flash("Master admin required", "danger")
         return redirect(url_for('admin'))
     if request.method == "POST":
-        if 'pos_threshold_1' in request.form:  # Handle VotingThresholdsForm
+        if 'port' in request.form:
+            form = PortForm(request.form)
+            if not form.validate_on_submit():
+                flash("Invalid port", "danger")
+                return redirect(url_for('admin_settings'))
+            try:
+                with DatabaseConnection() as conn:
+                    set_settings(conn, 'port', str(form.port.data))
+                flash('Port updated', 'success')
+                return redirect(url_for('admin_settings'))
+            except Exception as e:
+                logging.error(f"Error updating port: {str(e)}\n{traceback.format_exc()}")
+                flash('Server error updating port', 'danger')
+                return redirect(url_for('admin_settings'))
+        elif 'pos_threshold_1' in request.form:  # Handle VotingThresholdsForm
             form = VotingThresholdsForm(request.form)
             if not form.validate_on_submit():
                 logging.error("Voting thresholds form validation failed: %s", form.errors)
@@ -1878,6 +1893,10 @@ def admin_settings():
                         role_weights[role] = 1.0
                 set_settings(conn, 'role_vote_weights', json.dumps(role_weights))
             master_reset_form = MasterResetForm()
+            port_form = PortForm()
+            port_form.port.data = int(settings.get('port', 8101))
+            restart_service_form = RestartServiceForm()
+            reboot_pi_form = RebootPiForm()
 
         return render_template(
             "settings.html",
@@ -1890,6 +1909,9 @@ def admin_settings():
             vote_limits_form=vote_limits_form,
             scoreboard_form=scoreboard_form,
             master_reset_form=master_reset_form,
+            port_form=port_form,
+            restart_service_form=restart_service_form,
+            reboot_pi_form=reboot_pi_form,
             month_mode=settings.get('month_mode', 'calendar'),
             week_start_day=settings.get('week_start_day', 'Monday'),
             auto_vote_day=settings.get('auto_vote_day', ''),
@@ -1900,6 +1922,38 @@ def admin_settings():
         logging.error(f"Error in admin_settings GET: {str(e)}\n{traceback.format_exc()}")
         flash("Server error", "danger")
         return redirect(url_for('admin'))
+
+
+@app.route("/admin/restart_service", methods=["POST"])
+def admin_restart_service():
+    if "admin_id" not in session or session.get("admin_id") != "master":
+        flash("Master admin required", "danger")
+        return redirect(url_for('admin'))
+    form = RestartServiceForm()
+    if form.validate_on_submit():
+        try:
+            subprocess.run(["sudo", "systemctl", "restart", "incentive.service"], check=True)
+            flash("Service restart initiated", "success")
+        except Exception as e:
+            logging.error(f"Service restart failed: {str(e)}\n{traceback.format_exc()}")
+            flash("Failed to restart service", "danger")
+    return redirect(url_for('admin_settings'))
+
+
+@app.route("/admin/reboot_pi", methods=["POST"])
+def admin_reboot_pi():
+    if "admin_id" not in session or session.get("admin_id") != "master":
+        flash("Master admin required", "danger")
+        return redirect(url_for('admin'))
+    form = RebootPiForm()
+    if form.validate_on_submit():
+        try:
+            subprocess.run(["sudo", "reboot"], check=True)
+            flash("Rebooting", "success")
+        except Exception as e:
+            logging.error(f"Reboot failed: {str(e)}\n{traceback.format_exc()}")
+            flash("Failed to reboot", "danger")
+    return redirect(url_for('admin_settings'))
 
 
 @app.route("/employee", methods=["GET", "POST"])

--- a/forms.py
+++ b/forms.py
@@ -216,3 +216,16 @@ class ChangePinForm(FlaskForm):
     new_pin = PasswordField('New PIN', validators=[DataRequired(), Length(min=4, max=6)])
     submit = SubmitField('Change PIN')
 
+
+class PortForm(FlaskForm):
+    port = IntegerField('Port', validators=[DataRequired(), NumberRange(min=1, max=65535)])
+    submit = SubmitField('Update Port')
+
+
+class RestartServiceForm(FlaskForm):
+    submit = SubmitField('Restart Service')
+
+
+class RebootPiForm(FlaskForm):
+    submit = SubmitField('Reboot Pi')
+

--- a/incentive_service.py
+++ b/incentive_service.py
@@ -1205,6 +1205,9 @@ def get_settings(conn):
         if 'scoreboard_refresh_interval' not in settings:
             set_settings(conn, 'scoreboard_refresh_interval', '60')
             settings['scoreboard_refresh_interval'] = '60'
+        if 'port' not in settings:
+            set_settings(conn, 'port', '8101')
+            settings['port'] = '8101'
         for section in Config.ADMIN_SECTIONS:
             key = f'allow_section_{section}'
             if key not in settings:

--- a/init_db.py
+++ b/init_db.py
@@ -247,6 +247,7 @@ def initialize_incentive_db():
         ('surface_alt_color', '#1A1A1A'),
         ('strobe_mode', 'on'),
         ('sound_on', '1'),
+        ('port', '8101'),
         ('mini_game_settings', '{"award_chance_points":10,"award_chance_vote":15,"prizes":{"points":{"amount":5,"chance":20},"prize1":{"desc":"Gift Card","value":25,"chance":10},"prize2":{"desc":"Extra Break","value":0,"chance":30},"prize3":{"desc":"Company Swag","value":10,"chance":5}},"game_types":["slot","scratch","roulette"]}')
     ]
     default_settings.extend([(f'allow_section_{section}', '0') for section in Config.ADMIN_SECTIONS])

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/bash
 echo "Setting up RFID Incentive Program..."
 
+# Prompt for port
+read -p "Enter port for server [8101]: " PORT
+PORT=${PORT:-8101}
+
 # Create virtual environment
 python3 -m venv venv
 source venv/bin/activate
@@ -8,12 +12,20 @@ source venv/bin/activate
 # Install dependencies
 pip install flask gunicorn werkzeug
 
-# Initialize database
+# Initialize database and store chosen port
 python init_db.py
+python - <<EOF
+from config import Config
+import sqlite3
+conn = sqlite3.connect(Config.INCENTIVE_DB_FILE)
+conn.execute("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", ('port', '$PORT'))
+conn.commit()
+conn.close()
+EOF
 
 # Make start script executable
 chmod +x start.sh
 
 echo "Setup complete! To run the server, use './start.sh'"
-echo "To access, visit http://rfid:6800/"
+echo "To access, visit http://rfid:$PORT/"
 echo "Master Admin: username 'master', password 'Master8101'"

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,18 @@
 #!/usr/bin/bash
 source venv/bin/activate
-gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:8101 app:app
+PORT=$(python - <<'PY'
+from config import Config
+import sqlite3
+port = '8101'
+try:
+    conn = sqlite3.connect(Config.INCENTIVE_DB_FILE)
+    cur = conn.execute("SELECT value FROM settings WHERE key='port'")
+    row = cur.fetchone()
+    if row and row[0]:
+        port = row[0]
+finally:
+    conn.close()
+print(port)
+PY
+)
+gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:$PORT app:app

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -156,6 +156,23 @@
             <button type="submit" name="theme_settings" class="btn btn-primary">Update Theme</button>
         </form>
 
+        <h2>Server Port</h2>
+        <form action="{{ url_for('admin_settings') }}" method="POST" id="portForm">
+            {{ macros.render_csrf_token(id='port_csrf_token') }}
+            {{ macros.render_field(port_form.port, id='port_setting', label_text='Port', class='form-control', type='number', required=True, value=port_form.port.data) }}
+            {{ macros.render_submit_button('Update Port', class='btn btn-primary') }}
+        </form>
+
+        <h2>Service Control</h2>
+        <form action="{{ url_for('admin_restart_service') }}" method="POST" class="mb-2">
+            {{ macros.render_csrf_token(id='restart_service_csrf_token') }}
+            {{ macros.render_submit_button('Restart Service', class='btn btn-warning') }}
+        </form>
+        <form action="{{ url_for('admin_reboot_pi') }}" method="POST">
+            {{ macros.render_csrf_token(id='reboot_pi_csrf_token') }}
+            {{ macros.render_submit_button('Reboot Pi', class='btn btn-danger') }}
+        </form>
+
         <h2>Other Settings</h2>
         <form action="{{ url_for('admin_settings') }}" method="POST" id="settingsForm">
             {{ macros.render_csrf_token(id='settings_csrf_token') }}


### PR DESCRIPTION
## Summary
- prompt for server port during install and store in settings
- allow master admin to change port and restart service or reboot Pi
- start server using port value from database

## Testing
- `python -m py_compile app.py forms.py incentive_service.py init_db.py`
- `bash -n start.sh`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a4aabb0a24832589ccb466884c45f8