### PR TITLE
feat: configurable port and service controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,26 +131,14 @@ project-root/
 
 ## Setup & Installation
 
+Run the provided installation script to set up the application, choose a port, and install a systemd service that launches the app on boot:
+Ports below 1024 require root privileges; choose a port between 1024 and 65535.
+
 ```bash
-# 1. Clone repo and enter directory
-git clone https://github.com/sandahltim/incentive.git
-cd incentive
+./install.sh
+```
 
-# 2. Setup virtual environment
-python3 -m venv venv
-source venv/bin/activate
-
-# 3. Install dependencies
-pip install -r requirements.txt
-
-# 4. Set config as needed in config.py (default DB: incentive.db)
-
-# 5. Start the application (dev mode)
-flask run
-
-# OR for production
-gunicorn -w 4 -b 0.0.0.0:8000 app:app
-Database tables will be auto-created on first run if not found.
+The script creates a virtual environment, installs dependencies, initializes the database, and configures `/etc/systemd/system/incentive.service` (configurable via `Config.SERVICE_NAME`) to execute `start.sh`, which reads the port from the database. After installation the app will start automatically on reboot and can be managed from the master admin settings page.
 
 Configuration & Environment
 All runtime settings live in the settings table and are modifiable from the admin settings UI.
@@ -364,7 +352,7 @@ Decay is set by role and day; deducted points apply daily on specified days for 
 ## start.sh
 #!/bin/bash
 source venv/bin/activate
-gunicorn --workers 4 --timeout 180 --bind 0.0.0.0:6800 app:app
+gunicorn --workers 4 --timeout 180 --bind 0.0.0.0:$PORT app:app
 
 
 # init_db.py
@@ -620,7 +608,7 @@ matplotlib==3.9.1
 
 #!/bin/bash
 source venv/bin/activate
-gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:6800 app:app
+gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:$PORT app:app
 
 ## 🚀 Automatic Deployment from GitHub to Raspberry Pi (Self-Hosted Runner)
 

--- a/app.py
+++ b/app.py
@@ -8,7 +8,7 @@ from werkzeug.security import check_password_hash, generate_password_hash
 from flask_wtf.csrf import CSRFProtect, CSRFError
 from incentive_service import DatabaseConnection, get_scoreboard, start_voting_session, is_voting_active, cast_votes, add_employee, reset_scores, get_history, adjust_points, get_rules, add_rule, edit_rule, remove_rule, get_pot_info, update_pot_info, close_voting_session, pause_voting_session, resume_voting_session, finalize_voting_session, get_voting_results, master_reset_all, get_roles, add_role, edit_role, remove_role, edit_employee, reorder_rules, retire_employee, reactivate_employee, delete_employee, set_point_decay, get_point_decay, deduct_points_daily, get_latest_voting_results, add_feedback, get_unread_feedback_count, get_feedback, mark_feedback_read, delete_feedback, get_settings, set_settings, get_recent_admin_adjustments, award_mini_game, play_mini_game, verify_pin
 from config import Config
-from forms import VoteForm, AdminLoginForm, StartVotingForm, AddEmployeeForm, AdjustPointsForm, AddRuleForm, EditRuleForm, RemoveRuleForm, EditEmployeeForm, RetireEmployeeForm, ReactivateEmployeeForm, DeleteEmployeeForm, UpdatePotForm, UpdatePriorYearSalesForm, SetPointDecayForm, UpdateAdminForm, AddRoleForm, EditRoleForm, RemoveRoleForm, MasterResetForm, FeedbackForm, LogoutForm, PauseVotingForm, CloseVotingForm, ResetScoresForm, VotingThresholdsForm, VoteLimitsForm, ScoreboardSettingsForm, QuickAdjustForm, AwardGameForm, EmployeeLoginForm, ChangePinForm
+from forms import VoteForm, AdminLoginForm, StartVotingForm, AddEmployeeForm, AdjustPointsForm, AddRuleForm, EditRuleForm, RemoveRuleForm, EditEmployeeForm, RetireEmployeeForm, ReactivateEmployeeForm, DeleteEmployeeForm, UpdatePotForm, UpdatePriorYearSalesForm, SetPointDecayForm, UpdateAdminForm, AddRoleForm, EditRoleForm, RemoveRoleForm, MasterResetForm, FeedbackForm, LogoutForm, PauseVotingForm, CloseVotingForm, ResetScoresForm, VotingThresholdsForm, VoteLimitsForm, ScoreboardSettingsForm, QuickAdjustForm, AwardGameForm, EmployeeLoginForm, ChangePinForm, PortForm, RestartServiceForm, RebootPiForm
 import logging
 from logging_config import setup_logging
 import time
@@ -25,6 +25,7 @@ import matplotlib.pyplot as plt
 import os
 import json
 import random
+import subprocess
 
 # In-memory cache for /data endpoint
 _data_cache = None
@@ -1692,7 +1693,26 @@ def admin_settings():
         flash("Master admin required", "danger")
         return redirect(url_for('admin'))
     if request.method == "POST":
-        if 'pos_threshold_1' in request.form:  # Handle VotingThresholdsForm
+        if 'port' in request.form:
+            form = PortForm(request.form)
+            if not form.validate_on_submit():
+                flash("Invalid port", "danger")
+                return redirect(url_for('admin_settings'))
+            try:
+                with DatabaseConnection() as conn:
+                    set_settings(conn, 'port', str(form.port.data))
+                try:
+                    subprocess.run(["sudo", "systemctl", "restart", Config.SERVICE_NAME], check=True)
+                    flash('Port updated and service restarted', 'success')
+                except Exception as e:
+                    logging.error(f"Service restart failed after port update: {str(e)}\n{traceback.format_exc()}")
+                    flash('Port updated but failed to restart service', 'warning')
+                return redirect(url_for('admin_settings'))
+            except Exception as e:
+                logging.error(f"Error updating port: {str(e)}\n{traceback.format_exc()}")
+                flash('Server error updating port', 'danger')
+                return redirect(url_for('admin_settings'))
+        elif 'pos_threshold_1' in request.form:  # Handle VotingThresholdsForm
             form = VotingThresholdsForm(request.form)
             if not form.validate_on_submit():
                 logging.error("Voting thresholds form validation failed: %s", form.errors)
@@ -1878,6 +1898,10 @@ def admin_settings():
                         role_weights[role] = 1.0
                 set_settings(conn, 'role_vote_weights', json.dumps(role_weights))
             master_reset_form = MasterResetForm()
+            port_form = PortForm()
+            port_form.port.data = int(settings.get('port', 8101))
+            restart_service_form = RestartServiceForm()
+            reboot_pi_form = RebootPiForm()
 
         return render_template(
             "settings.html",
@@ -1890,6 +1914,9 @@ def admin_settings():
             vote_limits_form=vote_limits_form,
             scoreboard_form=scoreboard_form,
             master_reset_form=master_reset_form,
+            port_form=port_form,
+            restart_service_form=restart_service_form,
+            reboot_pi_form=reboot_pi_form,
             month_mode=settings.get('month_mode', 'calendar'),
             week_start_day=settings.get('week_start_day', 'Monday'),
             auto_vote_day=settings.get('auto_vote_day', ''),
@@ -1900,6 +1927,38 @@ def admin_settings():
         logging.error(f"Error in admin_settings GET: {str(e)}\n{traceback.format_exc()}")
         flash("Server error", "danger")
         return redirect(url_for('admin'))
+
+
+@app.route("/admin/restart_service", methods=["POST"])
+def admin_restart_service():
+    if "admin_id" not in session or session.get("admin_id") != "master":
+        flash("Master admin required", "danger")
+        return redirect(url_for('admin'))
+    form = RestartServiceForm()
+    if form.validate_on_submit():
+        try:
+            subprocess.run(["sudo", "systemctl", "restart", Config.SERVICE_NAME], check=True)
+            flash("Service restart initiated", "success")
+        except Exception as e:
+            logging.error(f"Service restart failed: {str(e)}\n{traceback.format_exc()}")
+            flash("Failed to restart service", "danger")
+    return redirect(url_for('admin_settings'))
+
+
+@app.route("/admin/reboot_pi", methods=["POST"])
+def admin_reboot_pi():
+    if "admin_id" not in session or session.get("admin_id") != "master":
+        flash("Master admin required", "danger")
+        return redirect(url_for('admin'))
+    form = RebootPiForm()
+    if form.validate_on_submit():
+        try:
+            subprocess.run(["sudo", "reboot"], check=True)
+            flash("Rebooting", "success")
+        except Exception as e:
+            logging.error(f"Reboot failed: {str(e)}\n{traceback.format_exc()}")
+            flash("Failed to reboot", "danger")
+    return redirect(url_for('admin_settings'))
 
 
 @app.route("/employee", methods=["GET", "POST"])

--- a/config.py
+++ b/config.py
@@ -1,6 +1,6 @@
 # config.py
-# Version: 1.2.6
-# Note: Changed SECRET_KEY to static value to fix CSRF session token missing error due to dynamic key generation. Maintained Config class and all attributes from version 1.2.5. Ensured compatibility with app.py (1.2.36), incentive_service.py (1.2.9), init_db.py (1.2.1), forms.py (1.2.2), incentive.html (1.2.17), admin_manage.html (1.2.17), quick_adjust.html (1.2.7), script.js (1.2.28), style.css (1.2.11). No changes to core configuration values.
+# Version: 1.2.7
+# Note: Added SERVICE_NAME for systemd integration while maintaining previous configuration values. Ensured compatibility with app.py (1.2.79+), incentive_service.py (1.2.22+), forms.py (1.2.7+), and related templates.
 
 import os
 
@@ -18,3 +18,6 @@ class Config:
     VOTE_CODE = "A1RentIt2025"
 
     ADMIN_SECTIONS = ['rules', 'manage_roles']
+
+    # Systemd service unit controlling the app
+    SERVICE_NAME = "incentive.service"

--- a/forms.py
+++ b/forms.py
@@ -216,3 +216,16 @@ class ChangePinForm(FlaskForm):
     new_pin = PasswordField('New PIN', validators=[DataRequired(), Length(min=4, max=6)])
     submit = SubmitField('Change PIN')
 
+
+class PortForm(FlaskForm):
+    port = IntegerField('Port', validators=[DataRequired(), NumberRange(min=1024, max=65535)])
+    submit = SubmitField('Update Port')
+
+
+class RestartServiceForm(FlaskForm):
+    submit = SubmitField('Restart Service')
+
+
+class RebootPiForm(FlaskForm):
+    submit = SubmitField('Reboot Pi')
+

--- a/incentive_service.py
+++ b/incentive_service.py
@@ -1205,6 +1205,9 @@ def get_settings(conn):
         if 'scoreboard_refresh_interval' not in settings:
             set_settings(conn, 'scoreboard_refresh_interval', '60')
             settings['scoreboard_refresh_interval'] = '60'
+        if 'port' not in settings:
+            set_settings(conn, 'port', '8101')
+            settings['port'] = '8101'
         for section in Config.ADMIN_SECTIONS:
             key = f'allow_section_{section}'
             if key not in settings:

--- a/init_db.py
+++ b/init_db.py
@@ -247,6 +247,7 @@ def initialize_incentive_db():
         ('surface_alt_color', '#1A1A1A'),
         ('strobe_mode', 'on'),
         ('sound_on', '1'),
+        ('port', '8101'),
         ('mini_game_settings', '{"award_chance_points":10,"award_chance_vote":15,"prizes":{"points":{"amount":5,"chance":20},"prize1":{"desc":"Gift Card","value":25,"chance":10},"prize2":{"desc":"Extra Break","value":0,"chance":30},"prize3":{"desc":"Company Swag","value":10,"chance":5}},"game_types":["slot","scratch","roulette"]}')
     ]
     default_settings.extend([(f'allow_section_{section}', '0') for section in Config.ADMIN_SECTIONS])

--- a/install.sh
+++ b/install.sh
@@ -1,5 +1,11 @@
-#!/usr/bin/bash
+#!/usr/bin/env bash
+set -e
+
 echo "Setting up RFID Incentive Program..."
+
+# Prompt for port
+read -p "Enter port for server [8101]: " PORT
+PORT=${PORT:-8101}
 
 # Create virtual environment
 python3 -m venv venv
@@ -8,12 +14,47 @@ source venv/bin/activate
 # Install dependencies
 pip install flask gunicorn werkzeug
 
-# Initialize database
+# Initialize database and store chosen port
 python init_db.py
+python - <<PY
+from config import Config
+import sqlite3
+conn = sqlite3.connect(Config.INCENTIVE_DB_FILE)
+conn.execute("INSERT OR REPLACE INTO settings (key, value) VALUES (?, ?)", ('port', '$PORT'))
+conn.commit()
+conn.close()
+PY
 
 # Make start script executable
 chmod +x start.sh
 
+# Configure systemd service to run the app on boot
+APP_DIR="$(pwd)"
+SERVICE_NAME=$(python - <<'PY'
+from config import Config
+print(getattr(Config, 'SERVICE_NAME', 'incentive.service'))
+PY
+)
+SERVICE_PATH="/etc/systemd/system/$SERVICE_NAME"
+sudo tee "$SERVICE_PATH" >/dev/null <<SERVICE
+[Unit]
+Description=RFID Incentive Program
+After=network.target
+
+[Service]
+Type=simple
+WorkingDirectory=$APP_DIR
+ExecStart=$APP_DIR/start.sh
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+sudo systemctl daemon-reload
+sudo systemctl enable "$SERVICE_NAME"
+sudo systemctl restart "$SERVICE_NAME"
+
 echo "Setup complete! To run the server, use './start.sh'"
-echo "To access, visit http://rfid:6800/"
+echo "To access, visit http://rfid:$PORT/"
 echo "Master Admin: username 'master', password 'Master8101'"

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,20 @@
 #!/usr/bin/bash
+# Ensure we run from the directory containing this script so relative paths work
+cd "$(dirname "$0")"
 source venv/bin/activate
-gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:8101 app:app
+PORT=$(python - <<'PY'
+from config import Config
+import sqlite3
+port = '8101'
+try:
+    conn = sqlite3.connect(Config.INCENTIVE_DB_FILE)
+    cur = conn.execute("SELECT value FROM settings WHERE key='port'")
+    row = cur.fetchone()
+    if row and row[0]:
+        port = row[0]
+finally:
+    conn.close()
+print(port)
+PY
+)
+exec gunicorn --workers 2 --timeout 180 --bind 0.0.0.0:$PORT app:app

--- a/templates/settings.html
+++ b/templates/settings.html
@@ -156,6 +156,23 @@
             <button type="submit" name="theme_settings" class="btn btn-primary">Update Theme</button>
         </form>
 
+        <h2>Server Port</h2>
+        <form action="{{ url_for('admin_settings') }}" method="POST" id="portForm">
+            {{ macros.render_csrf_token(id='port_csrf_token') }}
+            {{ macros.render_field(port_form.port, id='port_setting', label_text='Port', class='form-control', type='number', required=True, value=port_form.port.data) }}
+            {{ macros.render_submit_button('Update Port', class='btn btn-primary') }}
+        </form>
+
+        <h2>Service Control</h2>
+        <form action="{{ url_for('admin_restart_service') }}" method="POST" class="mb-2">
+            {{ macros.render_csrf_token(id='restart_service_csrf_token') }}
+            {{ macros.render_submit_button('Restart Service', class='btn btn-warning') }}
+        </form>
+        <form action="{{ url_for('admin_reboot_pi') }}" method="POST">
+            {{ macros.render_csrf_token(id='reboot_pi_csrf_token') }}
+            {{ macros.render_submit_button('Reboot Pi', class='btn btn-danger') }}
+        </form>
+
         <h2>Other Settings</h2>
         <form action="{{ url_for('admin_settings') }}" method="POST" id="settingsForm">
             {{ macros.render_csrf_token(id='settings_csrf_token') }}


### PR DESCRIPTION
## Summary
- clarify installation docs to avoid using privileged ports
- simplify port-update handler to just restart the configured systemd service
- validate port numbers above 1023 and harden installer with stricter bash settings

## Testing
- `python -m py_compile app.py forms.py incentive_service.py init_db.py config.py`
- `bash -n start.sh`
- `bash -n install.sh`


------
https://chatgpt.com/codex/tasks/task_e_68a4aabb0a24832589ccb466884c45f8