### PR TITLE
feat: add defensive checks for admin section toggling

### DIFF
--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -1779,9 +1779,23 @@ document.addEventListener('DOMContentLoaded', function() {
 
 function toggleSection(sectionName) {
     const section = document.querySelector(`[data-section="${sectionName}"]`);
+    if (!section) {
+        console.warn(`Unknown section: ${sectionName}`);
+        return;
+    }
+
     const content = section.querySelector('.section-content');
+    if (!content) {
+        console.warn(`Missing content for section: ${sectionName}`);
+        return;
+    }
+
     const icon = section.querySelector('.toggle-icon');
-    
+    if (!icon) {
+        console.warn(`Missing icon for section: ${sectionName}`);
+        return;
+    }
+
     if (content.classList.contains('expanded')) {
         content.classList.remove('expanded');
         content.style.maxHeight = '0';
@@ -1795,7 +1809,7 @@ function toggleSection(sectionName) {
         document.querySelectorAll('.toggle-icon').forEach(otherIcon => {
             otherIcon.style.transform = 'rotate(0deg)';
         });
-        
+
         // Open this section
         content.classList.add('expanded');
         content.style.maxHeight = 'none';


### PR DESCRIPTION
## Summary
- add validation of sections, content, and icons in admin panel toggle logic
- warn and exit gracefully when expected elements are missing

## Testing
- `pytest tests/test_analytics.py -q` *(fails: FileNotFoundError: Database file not found: /workspace/incent-A1/incentive.db)*

------
https://chatgpt.com/codex/tasks/task_e_68b12c261d9883259884c265b07af27d