### PR TITLE
refactor: rely on bootstrap modal

### DIFF
--- a/templates/admin_manage.html
+++ b/templates/admin_manage.html
@@ -479,7 +479,7 @@
                         <h3>Employee Management</h3>
                     </div>
                     <div class="section-controls">
-                        <button class="btn btn-sm btn-success" onclick="showAddEmployeeModal()">
+                        <button class="btn btn-sm btn-success" data-bs-toggle="modal" data-bs-target="#addEmployeeModal">
                             <i class="fas fa-user-plus"></i> Add Employee
                         </button>
                         <i class="fas fa-chevron-down toggle-icon"></i>
@@ -1954,23 +1954,6 @@ function toggleEmployeeStatus(employeeId, activate) {
     }
 }
 
-function showAddEmployeeModal() {
-    // Clear any existing modal backdrops first
-    document.querySelectorAll('.modal-backdrop').forEach(backdrop => backdrop.remove());
-    
-    const modalElement = document.getElementById('addEmployeeModal');
-    if (!modalElement) {
-        console.error('Add Employee Modal not found');
-        return;
-    }
-    
-    const modal = new bootstrap.Modal(modalElement, {
-        backdrop: 'static',
-        keyboard: false
-    });
-    modal.show();
-}
-
 // Game management functions
 function revokeGame(gameId) {
     if (confirm('Are you sure you want to revoke this unused game token?')) {
@@ -3025,7 +3008,7 @@ async function executeAutoRules() {
 <!-- Modal Dialogs -->
 
 <!-- Add Employee Modal -->
-<div class="modal fade" id="addEmployeeModal" tabindex="-1">
+<div class="modal fade" id="addEmployeeModal" tabindex="-1" aria-hidden="true">
     <div class="modal-dialog">
         <div class="modal-content">
             <div class="modal-header">


### PR DESCRIPTION
## Summary
- simplify Add Employee modal trigger using Bootstrap data attributes
- drop custom showAddEmployeeModal JavaScript
- rely on Bootstrap backdrop with proper modal attributes

## Testing
- `pytest tests/test_auth.py -q` *(fails: ImportError: cannot import name 'AnalyticsService')*

------
https://chatgpt.com/codex/tasks/task_e_68b12cd06e688325a6b483ac6cffa2ff